### PR TITLE
Support multiple files in Result.from_hash

### DIFF
--- a/lib/simplecov/result.rb
+++ b/lib/simplecov/result.rb
@@ -66,11 +66,15 @@ module SimpleCov
 
     # Loads a SimpleCov::Result#to_hash dump
     def self.from_hash(hash)
-      command_name, data = hash.first
-      result = SimpleCov::Result.new(data["coverage"])
-      result.command_name = command_name
-      result.created_at = Time.at(data["timestamp"])
-      result
+      results = []
+      hash.each do |command_name, data|
+        command_name, data = hash.first
+        result = SimpleCov::Result.new(data["coverage"])
+        result.command_name = command_name
+        result.created_at = Time.at(data["timestamp"])
+        results << result
+      end
+      results
     end
 
   private

--- a/lib/simplecov/result_merger.rb
+++ b/lib/simplecov/result_merger.rb
@@ -51,15 +51,17 @@ module SimpleCov
       # All results that are above the SimpleCov.merge_timeout will be
       # dropped. Returns an array of SimpleCov::Result items.
       def results
-        results = []
+        all = []
         resultset.each do |command_name, data|
-          result = SimpleCov::Result.from_hash(command_name => data)
+          results = SimpleCov::Result.from_hash(command_name => data)
           # Only add result if the timeout is above the configured threshold
-          if (Time.now - result.created_at) < SimpleCov.merge_timeout
-            results << result
+          results.each do |result|
+            if (Time.now - result.created_at) < SimpleCov.merge_timeout
+              all << result
+            end
           end
         end
-        results
+        all
       end
 
       # Merge two or more SimpleCov::Results into a new one with merged

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -77,11 +77,11 @@ if SimpleCov.usable?
 
           context "loaded back with from_hash" do
             let(:dumped_result) do
-              SimpleCov::Result.from_hash(subject.to_hash)
+              SimpleCov::Result.from_hash(subject.to_hash).first
             end
 
             it "has 3 source files" do
-              expect(dumped_result.source_files.count).to eq(subject.source_files.count)
+              expect(dumped_result.first.source_files.count).to eq(subject.source_files.count)
             end
 
             it "has the same covered_percent" do

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -81,7 +81,7 @@ if SimpleCov.usable?
             end
 
             it "has 3 source files" do
-              expect(dumped_result.first.source_files.count).to eq(subject.source_files.count)
+              expect(dumped_result.source_files.count).to eq(subject.source_files.count)
             end
 
             it "has the same covered_percent" do


### PR DESCRIPTION
Result.from_hash is used to merge resultsets when the tests are run in
parallel across machines using things like `parallel_tests`. In the
above scenario each machine can have multiple results sets as one would
want to run as many parallel spec process as the machine has cores. The
merge result code only consumes the first result, and dropping the rest.

In this PR I fix it by returning arrays through out.