### PR TITLE
Change Result#from_hash to deal with many entries isntead one

### DIFF
--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -85,13 +85,11 @@ module SimpleCov
 
       results = result_filenames.flat_map do |filename|
         # Re-create each included instance of SimpleCov::Result from the stored run data.
-        (JSON.parse(File.read(filename)) || {}).map do |command_name, coverage|
-          SimpleCov::Result.from_hash(command_name => coverage)
-        end
+        Result.from_hash(JSON.parse(File.read(filename)) || {})
       end
 
       # Use the ResultMerger to produce a single, merged result, ready to use.
-      @result = SimpleCov::ResultMerger.merge_and_store(*results)
+      @result = ResultMerger.merge_and_store(*results)
 
       run_exit_tasks!
     end

--- a/lib/simplecov/result_merger.rb
+++ b/lib/simplecov/result_merger.rb
@@ -53,13 +53,8 @@ module SimpleCov
       # All results that are above the SimpleCov.merge_timeout will be
       # dropped. Returns an array of SimpleCov::Result items.
       def results
-        results = []
-        resultset.each do |command_name, data|
-          result = SimpleCov::Result.from_hash(command_name => data)
-          # Only add result if the timeout is above the configured threshold
-          results << result if (Time.now - result.created_at) < SimpleCov.merge_timeout
-        end
-        results
+        results = Result.from_hash(resultset)
+        results.select { |result| result.time_since_creation < SimpleCov.merge_timeout }
       end
 
       def merge_and_store(*results)

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -76,7 +76,7 @@ describe SimpleCov::Result do
 
         context "loaded back with from_hash" do
           let(:dumped_result) do
-            SimpleCov::Result.from_hash(subject.to_hash)
+            SimpleCov::Result.from_hash(subject.to_hash).first
           end
 
           it "has 3 source files" do

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -205,6 +205,36 @@ describe SimpleCov::Result do
         end
       end
     end
+
+    describe ".from_hash" do
+      let(:other_result) do
+        {
+          source_fixture("sample.rb") => {"lines" => [nil, 1, 1, 1, nil, nil, 0, 0, nil, nil]}
+        }
+      end
+      let(:created_at) { Time.now.to_i }
+
+      it "can consume multiple commands" do
+        input = {
+          "rspec" => {
+            "coverage" => original_result,
+            "timestamp" => created_at
+          },
+          "cucumber" => {
+            "coverage" => other_result,
+            "timestamp" => created_at
+          }
+        }
+
+        result = described_class.from_hash(input)
+
+        expect(result.size).to eq 2
+        sorted = result.sort_by(&:command_name)
+        expect(sorted.map(&:command_name)).to eq %w[cucumber rspec]
+        expect(sorted.map(&:created_at).map(&:to_i)).to eq [created_at, created_at]
+        expect(sorted.map(&:original_result)).to eq [other_result, original_result]
+      end
+    end
   end
 
   context "with outdated result format" do


### PR DESCRIPTION
Inspired by #687

This feels cleaner as we have one centralized instead of 2
things making up their own loop leaking knowledge about the
data structure. That knowledge is now more contained in the
Result class which is great.

Using select also feels much better.

If anyone was using Result.from_hash we might break their code
as it's an Array now. I hope not/nobody should :)