### PR TITLE
Invalidate coverage_path cache for updating root

### DIFF
--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -22,6 +22,7 @@ module SimpleCov
     def root(root = nil)
       return @root if defined?(@root) && root.nil?
 
+      @coverage_path = nil # invalidate cache
       @root = File.expand_path(root || Dir.getwd)
     end
 


### PR DESCRIPTION
As updating `coverage_dir`, updating `root` should invalidate `coverage_path` cache.