### PR TITLE
Remove flakyness from see source files step

### DIFF
--- a/features/skipping_code_blocks_manually.feature
+++ b/features/skipping_code_blocks_manually.feature
@@ -57,15 +57,15 @@ Feature:
 
     When I open the coverage report generated with `bundle exec rake test`
 
-    Then I should see the source files:
+    Then the report should be based upon:
+      | Unit Tests |
+
+    And there should be 7 skipped lines in the source files
+
+    And I should see the source files:
       | name                                    | coverage |
       | lib/faked_project.rb                    | 100.00 %  |
       | lib/faked_project/some_class.rb         | 80.00 %   |
       | lib/faked_project/framework_specific.rb | 75.00 %   |
       | lib/faked_project/meta_magic.rb         | 100.00 %  |
       | lib/faked_project/nocov.rb              | 100.00 %  |
-
-    And there should be 7 skipped lines in the source files
-
-    And the report should be based upon:
-      | Unit Tests |

--- a/features/step_definitions/html_steps.rb
+++ b/features/step_definitions/html_steps.rb
@@ -2,9 +2,8 @@
 
 Then /^I should see the groups:$/ do |table|
   expected_groups = table.hashes
-  available_groups = all("#content .file_list_container")
   # Given group names should be the same number than those rendered in report
-  expect(expected_groups.count).to eq(available_groups.count)
+  expect(page).to have_css("#content .file_list_container", count: expected_groups.count)
 
   # Verify each of the expected groups has a file list container and corresponding title and coverage number
   # as well as the correct number of links to files.
@@ -23,9 +22,8 @@ end
 
 Then /^I should see the source files:$/ do |table|
   expected_files = table.hashes
-  available_source_files = all(".t-file", visible: true)
+  available_source_files = all(".t-file", visible: true, count: expected_files.count)
 
-  expect(expected_files.length).to eq(available_source_files.count)
   include_branch_coverage = table.column_names.include?("branch coverage")
 
   # Find all filenames and their coverage present in coverage report


### PR DESCRIPTION
As we're first querying the visible files and then comparing
the expected counts we're not making use of capybaras waiting
in case they're not loaded yet. This change embeds the expectation
in the query making use of the patient waiting and functioning
as an expectation at the same time.

#925 