### PR TITLE
simplecov.rb - fix Process monkey patch for fork when unsupported

### DIFF
--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -50,7 +50,9 @@ module SimpleCov
     def start(profile = nil, &block)
       require "coverage"
       initial_setup(profile, &block)
-      require_relative "./simplecov/process" if SimpleCov.enabled_for_subprocesses?
+      require_relative "./simplecov/process" if SimpleCov.enabled_for_subprocesses? &&
+                                                ::Process.respond_to?(:fork)
+
       make_parallel_tests_available
 
       @result = nil


### PR DESCRIPTION
Monkey patching `Process.fork` causes issues with applications that make use of fork but also run on Ruby builds without fork (like Windows & JRuby).

Fix so `./simplecov/process.rb` is only required if the platform supports `Process.fork`.