### PR TITLE
Fix the benchmark

### DIFF
--- a/benchmarks/result.rb
+++ b/benchmarks/result.rb
@@ -6,7 +6,7 @@ require "coverage"
 Coverage.start
 # such meta, many wow
 require_relative "../lib/simplecov"
-require_relative "../spec/faked_project/lib/faked_project"
+require_relative "../test_projects/faked_project/lib/faked_project"
 result = Coverage.result
 
 class MyFormatter


### PR DESCRIPTION
The only benchmark got accidentally broken when all the test projects were moved from `./spec/test_projects` to `./test_projects` in https://github.com/simplecov-ruby/simplecov/pull/814. This PR fixes it.

Before:

```
➜  simplecov git:(main) ruby benchmarks/result.rb
Traceback (most recent call last):
	1: from benchmarks/result.rb:9:in `<main>'
benchmarks/result.rb:9:in `require_relative': cannot load such file -- /Users/dnnx/work/simplecov/spec/faked_project/lib/faked_project (LoadError)
```

After:

```
➜  simplecov git:(fix-benchmarks) ruby benchmarks/result.rb
Warming up --------------------------------------
generating a simplecov result
                         7.000  i/100ms
Calculating -------------------------------------
generating a simplecov result
                         78.386  (± 1.3%) i/s -    392.000  in   5.002603s
```

Can I haz my [t-shirt](https://twitter.com/shitoberfest) now very please?

Just kidding, I don't care about the t-shirt.
