### PR TITLE
 Prevent an "instance variable not initialized" warning

### DIFF
--- a/features/warnings.feature
+++ b/features/warnings.feature
@@ -1,0 +1,18 @@
+@rspec
+Feature:
+
+  Running SimpleCov with verbosity enabled does not yield warnings.
+
+  Background:
+    Given I'm working on the project "faked_project"
+
+  Scenario:
+    Given SimpleCov for RSpec is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start
+      """
+
+    When I successfully run `bundle exec rspec --warnings spec`
+    Then a coverage report should have been generated
+    And the output should not contain "warning"

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -199,8 +199,9 @@ module SimpleCov
     # gets or sets the enabled_for_subprocess configuration
     # when true, this will inject SimpleCov code into Process.fork
     def enable_for_subprocesses(value = nil)
-      @enable_for_subprocesses = value unless value.nil?
-      @enable_for_subprocesses || false
+      return @enable_for_subprocesses if defined?(@enable_for_subprocesses) && value.nil?
+
+      @enable_for_subprocesses = value || false
     end
 
     # gets the enabled_for_subprocess configuration

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -183,5 +183,24 @@ describe SimpleCov::Configuration do
         expect(config).not_to be_branch_coverage
       end
     end
+
+    describe "#enable_for_subprocesses" do
+      it "returns false by default" do
+        expect(config.enable_for_subprocesses).to eq false
+      end
+
+      it "can be set to true" do
+        config.enable_for_subprocesses true
+
+        expect(config.enable_for_subprocesses).to eq true
+      end
+
+      it "can be enabled and then disabled again" do
+        config.enable_for_subprocesses true
+        config.enable_for_subprocesses false
+
+        expect(config.enable_for_subprocesses).to eq false
+      end
+    end
   end
 end


### PR DESCRIPTION
Original is  #928

Fixes #926 