### PR TITLE
Minor performance improvements

### DIFF
--- a/lib/simplecov/lines_classifier.rb
+++ b/lib/simplecov/lines_classifier.rb
@@ -17,14 +17,14 @@ module SimpleCov
     end
 
     def self.no_cov_line?(line)
-      line =~ no_cov_line
+      no_cov_line.match?(line)
     rescue ArgumentError
       # E.g., line contains an invalid byte sequence in UTF-8
       false
     end
 
     def self.whitespace_line?(line)
-      line =~ WHITESPACE_OR_COMMENT_LINE
+      WHITESPACE_OR_COMMENT_LINE.match?(line)
     rescue ArgumentError
       # E.g., line contains an invalid byte sequence in UTF-8
       false

--- a/lib/simplecov/source_file/line.rb
+++ b/lib/simplecov/source_file/line.rb
@@ -56,7 +56,7 @@ module SimpleCov
       # Returns true if this line was skipped, false otherwise. Lines are skipped if they are wrapped with
       # # :nocov: comment lines.
       def skipped?
-        !!skipped
+        skipped
       end
 
       # The status of this line - either covered, missed, skipped or never. Useful i.e. for direct use


### PR DESCRIPTION
This PR aims to improve performance of SimpleCov a bit.

See individual commits message for more details.

## Micro benchmarks

```
$ ruby -v
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]
```

### For ["Improve performance by removing `!!` checking bool"](https://github.com/simplecov-ruby/simplecov/commit/9e5bf402bc1b900d790a7d20ccf7bb5ce34d0a36)

```ruby
# frozen_string_literal: true

require "benchmark/ips"

class Foo
  attr_reader :skipped

  def initialized
    @skipped = false
  end

  def skipped?
    !!skipped
  end

  def skipped2?
    skipped
  end
end

foo = Foo.new

Benchmark.ips do |x|
  x.report "old" do
    foo.skipped?
  end

  x.report "new" do
    foo.skipped2?
  end

  x.compare!
end

# Warming up --------------------------------------
#                  old     1.484M i/100ms
#                  new     1.662M i/100ms
# Calculating -------------------------------------
#                  old     14.627M (± 3.1%) i/s -     74.208M in   5.078872s
#                  new     16.783M (± 1.5%) i/s -     84.751M in   5.050889s
#
# Comparison:
#                  new: 16783088.9 i/s
#                  old: 14626816.9 i/s - 1.15x  (± 0.00) slower
```

### For [Improve performance of lines classifier](https://github.com/simplecov-ruby/simplecov/commit/7191e9c468f29cfb09347271b826b49d9475035c)

```ruby
# frozen_string_literal: true

require "benchmark/ips"

string = "ok"
regexp = /ok/

Benchmark.ips do |x|
  x.report "old" do
    string =~ regexp
  end

  x.report "new" do
    regexp.match?(string)
  end

  x.compare!
end

# Warming up --------------------------------------
#                  old   522.978k i/100ms
#                  new   837.506k i/100ms
# Calculating -------------------------------------
#                  old      5.069M (± 3.2%) i/s -     25.626M in   5.060956s
#                  new      7.925M (± 3.3%) i/s -     40.200M in   5.078645s
#
# Comparison:
#                  new:  7924707.0 i/s
#                  old:  5068893.1 i/s - 1.56x  (± 0.00) slower
```