### PR TITLE
Allows switching primary coverage to something other than line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 
 ## Enhancements
 * Can now define the minimum_coverage_by_file, maximum_coverage_drop and refuse_coverage_drop by branch as well as line coverage
+* Can set primary coverage to something other than line by setting `primary_coverage: branch` in SimpleCov Configuration
 
 0.20.0 (2020-11-29)
 ==========

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Unreleased
 
 ## Enhancements
 * Can now define the minimum_coverage_by_file, maximum_coverage_drop and refuse_coverage_drop by branch as well as line coverage
-* Can set primary coverage to something other than line by setting `primary_coverage: branch` in SimpleCov Configuration
+* Can set primary coverage to something other than line by setting `primary_coverage :branch` in SimpleCov Configuration
 
 0.20.0 (2020-11-29)
 ==========

--- a/README.md
+++ b/README.md
@@ -341,6 +341,22 @@ Hence, we recommend looking at both metrics together. Branch coverage might also
 overall metric to look at - while you might be missing only 10% of your lines that might
 account for 50% of your branches for instance.
 
+## Primary Coverage
+
+By default, the primary coverage type is `line`. To set the primary coverage to something else, use the following:
+
+```ruby
+# or in configure SimpleCov.primary_coverage :branch
+SimpleCov.start do
+  enable_coverage :branch
+  primary_coverage :branch
+end
+```
+
+Primary coverage determines what will come in first all output, and the type of coverage to check if you don't specify the type of coverage when customizing exit behavior (`SimpleCov.minimum_coverage 90`).
+
+Note that coverage must first be enabled for non-default coverage types.
+
 ## Filters
 
 Filters can be used to remove selected files from your coverage data. By default, a filter is applied that removes all

--- a/README.md
+++ b/README.md
@@ -295,7 +295,6 @@ information to be lost.
 Add branch coverage measurement statistics to your results. Supported in CRuby versions 2.5+.
 
 ```ruby
-# or in configure or just SimpleCov.enable_coverage :branch
 SimpleCov.start do
   enable_coverage :branch
 end

--- a/features/maximum_coverage_drop.feature
+++ b/features/maximum_coverage_drop.feature
@@ -267,7 +267,6 @@ Feature:
     And the output should contain "Branch coverage has dropped by 50.00% since the last time (maximum allowed: 0.00%)."
     And the output should contain "SimpleCov failed with exit 3"
 
-  @primary_coverage
   Scenario: Can set branch as primary coverage and it will fail if branch is below maximum coverage drop
     Given SimpleCov for Test/Unit is configured with:
       """
@@ -275,7 +274,7 @@ Feature:
       SimpleCov.start do
         add_filter 'test.rb'
         enable_coverage :branch
-	primary_coverage :branch
+        primary_coverage :branch
         maximum_coverage_drop 0
       end
       """
@@ -304,7 +303,7 @@ Feature:
       {
         "result": {
           "line": 100.0,
-	  "branch": 100.0
+          "branch": 100.0
         }
       }
       """
@@ -358,5 +357,6 @@ Feature:
 
     When I run `bundle exec rake test`
     Then the exit status should not be 0
-    And the output should contain "Branch coverage has dropped by 50.00% since the last time (maximum allowed: 0.00%).\nLine coverage has dropped by 15.22% since the last time (maximum allowed: 0.00%)."
+    And the output should contain "Branch coverage has dropped by 50.00% since the last time (maximum allowed: 0.00%)."
+    And the output should contain "Line coverage has dropped by 15.22% since the last time (maximum allowed: 0.00%)."
     And the output should contain "SimpleCov failed with exit 3"

--- a/features/maximum_coverage_drop.feature
+++ b/features/maximum_coverage_drop.feature
@@ -266,3 +266,97 @@ Feature:
     And the output should contain "Line coverage has dropped by 15.22% since the last time (maximum allowed: 0.00%)."
     And the output should contain "Branch coverage has dropped by 50.00% since the last time (maximum allowed: 0.00%)."
     And the output should contain "SimpleCov failed with exit 3"
+
+  @primary_coverage
+  Scenario: Can set branch as primary coverage and it will fail if branch is below maximum coverage drop
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start do
+        add_filter 'test.rb'
+        enable_coverage :branch
+	primary_coverage :branch
+        maximum_coverage_drop 0
+      end
+      """
+    And a file named "lib/faked_project/missed.rb" with:
+      """
+      class UncoveredSourceCode
+        def foo
+          never_reached
+        rescue => err
+          but no one cares about invalid ruby here
+        end
+      end
+      """
+
+    And a file named "spec/failing_spec.rb" with:
+      """
+      require "spec_helper"
+      describe FakedProject do
+        it "fails" do
+          false ? true : expect(false).to eq(true)
+        end
+      end
+      """
+    And the file named "coverage/.last_run.json" with:
+      """
+      {
+        "result": {
+          "line": 100.0,
+	  "branch": 100.0
+        }
+      }
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should not be 0
+    And the output should not contain "Line coverage"
+    And the output should contain "Branch coverage has dropped by 50.00% since the last time (maximum allowed: 0.00%)."
+    And the output should contain "SimpleCov failed with exit 3"
+
+  Scenario: Can set branch as primary coverage and it will fail if branch is below maximum coverage drop
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start do
+        add_filter 'test.rb'
+        enable_coverage :branch
+	primary_coverage :branch
+	maximum_coverage_drop line: 0, branch: 0
+      end
+      """
+    And a file named "lib/faked_project/missed.rb" with:
+      """
+      class UncoveredSourceCode
+        def foo
+          never_reached
+        rescue => err
+          but no one cares about invalid ruby here
+        end
+      end
+      """
+
+    And a file named "spec/failing_spec.rb" with:
+      """
+      require "spec_helper"
+      describe FakedProject do
+        it "fails" do
+          false ? true : expect(false).to eq(true)
+        end
+      end
+      """
+    And the file named "coverage/.last_run.json" with:
+      """
+      {
+        "result": {
+          "line": 100.0,
+	  "branch": 100.0
+        }
+      }
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should not be 0
+    And the output should contain "Branch coverage has dropped by 50.00% since the last time (maximum allowed: 0.00%).\nLine coverage has dropped by 15.22% since the last time (maximum allowed: 0.00%)."
+    And the output should contain "SimpleCov failed with exit 3"

--- a/features/maximum_coverage_drop.feature
+++ b/features/maximum_coverage_drop.feature
@@ -267,6 +267,7 @@ Feature:
     And the output should contain "Branch coverage has dropped by 50.00% since the last time (maximum allowed: 0.00%)."
     And the output should contain "SimpleCov failed with exit 3"
 
+  @branch_coverage
   Scenario: Can set branch as primary coverage and it will fail if branch is below maximum coverage drop
     Given SimpleCov for Test/Unit is configured with:
       """
@@ -314,6 +315,7 @@ Feature:
     And the output should contain "Branch coverage has dropped by 50.00% since the last time (maximum allowed: 0.00%)."
     And the output should contain "SimpleCov failed with exit 3"
 
+  @branch_coverage
   Scenario: Can set branch as primary coverage and it will fail if branch is below maximum coverage drop
     Given SimpleCov for Test/Unit is configured with:
       """

--- a/features/minimum_coverage.feature
+++ b/features/minimum_coverage.feature
@@ -80,6 +80,7 @@ Feature:
     And the output should contain "Branch coverage (50.00%) is below the expected minimum coverage (80.00%)."
     And the output should contain "SimpleCov failed with exit 2"
 
+  @branch_coverage
   Scenario: Can set branch as primary coverage and it will fail if branch is below minimum coverage
     Given SimpleCov for Test/Unit is configured with:
       """

--- a/features/minimum_coverage.feature
+++ b/features/minimum_coverage.feature
@@ -80,7 +80,6 @@ Feature:
     And the output should contain "Branch coverage (50.00%) is below the expected minimum coverage (80.00%)."
     And the output should contain "SimpleCov failed with exit 2"
 
-  @primary_coverage
   Scenario: Can set branch as primary coverage and it will fail if branch is below minimum coverage
     Given SimpleCov for Test/Unit is configured with:
       """
@@ -88,7 +87,7 @@ Feature:
       SimpleCov.start do
         add_filter 'test.rb'
         enable_coverage :branch
-	primary_coverage :branch
+        primary_coverage :branch
         minimum_coverage 80
       end
       """
@@ -97,21 +96,4 @@ Feature:
     Then the exit status should not be 0
     And the output should contain "Branch coverage (50.00%) is below the expected minimum coverage (80.00%)."
     And the output should not contain "Line coverage"
-    And the output should contain "SimpleCov failed with exit 2"
-
-  Scenario: Prioritizes branch coverage in output when it's the primary coverage
-    Given SimpleCov for Test/Unit is configured with:
-      """
-      require 'simplecov'
-      SimpleCov.start do
-        add_filter 'test.rb'
-        enable_coverage :branch
-        primary_coverage :branch
-        minimum_coverage line: 90, branch: 80
-      end
-      """
-
-    When I run `bundle exec rake test`
-    Then the exit status should not be 0
-    And the output should contain "Branch coverage (50.00%) is below the expected minimum coverage (80.00%).\nLine coverage (88.09%) is below the expected minimum coverage (90.00%)."
     And the output should contain "SimpleCov failed with exit 2"

--- a/features/minimum_coverage.feature
+++ b/features/minimum_coverage.feature
@@ -79,3 +79,39 @@ Feature:
     And the output should contain "Line coverage (88.09%) is below the expected minimum coverage (90.00%)."
     And the output should contain "Branch coverage (50.00%) is below the expected minimum coverage (80.00%)."
     And the output should contain "SimpleCov failed with exit 2"
+
+  @primary_coverage
+  Scenario: Can set branch as primary coverage and it will fail if branch is below minimum coverage
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start do
+        add_filter 'test.rb'
+        enable_coverage :branch
+	primary_coverage :branch
+        minimum_coverage 80
+      end
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should not be 0
+    And the output should contain "Branch coverage (50.00%) is below the expected minimum coverage (80.00%)."
+    And the output should not contain "Line coverage"
+    And the output should contain "SimpleCov failed with exit 2"
+
+  Scenario: Prioritizes branch coverage in output when it's the primary coverage
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start do
+        add_filter 'test.rb'
+        enable_coverage :branch
+        primary_coverage :branch
+        minimum_coverage line: 90, branch: 80
+      end
+      """
+
+    When I run `bundle exec rake test`
+    Then the exit status should not be 0
+    And the output should contain "Branch coverage (50.00%) is below the expected minimum coverage (80.00%).\nLine coverage (88.09%) is below the expected minimum coverage (90.00%)."
+    And the output should contain "SimpleCov failed with exit 2"

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -290,11 +290,11 @@ module SimpleCov
     def minimum_coverage(coverage = nil)
       return @minimum_coverage ||= {} unless coverage
 
-      coverage = {DEFAULT_COVERAGE_CRITERION => coverage} if coverage.is_a?(Numeric)
+      coverage = {default_coverage_criterion => coverage} if coverage.is_a?(Numeric)
 
       raise_on_invalid_coverage(coverage, "minimum_coverage")
 
-      @minimum_coverage = coverage
+      @minimum_coverage = order_default_first(coverage)
     end
 
     def raise_on_invalid_coverage(coverage, coverage_setting)
@@ -313,11 +313,11 @@ module SimpleCov
     def maximum_coverage_drop(coverage_drop = nil)
       return @maximum_coverage_drop ||= {} unless coverage_drop
 
-      coverage_drop = {DEFAULT_COVERAGE_CRITERION => coverage_drop} if coverage_drop.is_a?(Numeric)
+      coverage_drop = {default_coverage_criterion => coverage_drop} if coverage_drop.is_a?(Numeric)
 
       raise_on_invalid_coverage(coverage_drop, "maximum_coverage_drop")
 
-      @maximum_coverage_drop = coverage_drop
+      @maximum_coverage_drop = order_default_first(coverage_drop)
     end
 
     #
@@ -330,11 +330,11 @@ module SimpleCov
     def minimum_coverage_by_file(coverage = nil)
       return @minimum_coverage_by_file ||= {} unless coverage
 
-      coverage = {DEFAULT_COVERAGE_CRITERION => coverage} if coverage.is_a?(Numeric)
+      coverage = {default_coverage_criterion => coverage} if coverage.is_a?(Numeric)
 
       raise_on_invalid_coverage(coverage, "minimum_coverage_by_file")
 
-      @minimum_coverage_by_file = coverage
+      @minimum_coverage_by_file = order_default_first(coverage)
     end
 
     #
@@ -391,7 +391,7 @@ module SimpleCov
     # @param [Symbol] criterion
     #
     def coverage_criterion(criterion = nil)
-      return @coverage_criterion ||= DEFAULT_COVERAGE_CRITERION unless criterion
+      return @coverage_criterion ||= default_coverage_criterion unless criterion
 
       raise_if_criterion_unsupported(criterion)
 
@@ -404,8 +404,21 @@ module SimpleCov
       coverage_criteria << criterion
     end
 
+    def primary_coverage(criterion)
+      default_coverage_criterion(criterion)
+    end
+
     def coverage_criteria
-      @coverage_criteria ||= Set[DEFAULT_COVERAGE_CRITERION]
+      @coverage_criteria ||= Set[default_coverage_criterion]
+    end
+
+    def default_coverage_criterion(criterion = nil)
+      if criterion.nil?
+        @default_coverage_criterion ||= DEFAULT_COVERAGE_CRITERION
+      else
+        raise_if_criterion_disabled(criterion)
+        @default_coverage_criterion = criterion
+      end
     end
 
     def coverage_criterion_enabled?(criterion)
@@ -454,6 +467,12 @@ module SimpleCov
 
     def minimum_possible_coverage_exceeded(coverage_option)
       warn "The coverage you set for #{coverage_option} is greater than 100%"
+    end
+
+    def order_default_first(coverage)
+      {
+        default_coverage_criterion => coverage[default_coverage_criterion]
+      }.merge(coverage).compact
     end
 
     #

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -290,11 +290,11 @@ module SimpleCov
     def minimum_coverage(coverage = nil)
       return @minimum_coverage ||= {} unless coverage
 
-      coverage = {default_coverage_criterion => coverage} if coverage.is_a?(Numeric)
+      coverage = {primary_coverage => coverage} if coverage.is_a?(Numeric)
 
       raise_on_invalid_coverage(coverage, "minimum_coverage")
 
-      @minimum_coverage = order_default_first(coverage)
+      @minimum_coverage = coverage
     end
 
     def raise_on_invalid_coverage(coverage, coverage_setting)
@@ -313,11 +313,11 @@ module SimpleCov
     def maximum_coverage_drop(coverage_drop = nil)
       return @maximum_coverage_drop ||= {} unless coverage_drop
 
-      coverage_drop = {default_coverage_criterion => coverage_drop} if coverage_drop.is_a?(Numeric)
+      coverage_drop = {primary_coverage => coverage_drop} if coverage_drop.is_a?(Numeric)
 
       raise_on_invalid_coverage(coverage_drop, "maximum_coverage_drop")
 
-      @maximum_coverage_drop = order_default_first(coverage_drop)
+      @maximum_coverage_drop = coverage_drop
     end
 
     #
@@ -330,11 +330,11 @@ module SimpleCov
     def minimum_coverage_by_file(coverage = nil)
       return @minimum_coverage_by_file ||= {} unless coverage
 
-      coverage = {default_coverage_criterion => coverage} if coverage.is_a?(Numeric)
+      coverage = {primary_coverage => coverage} if coverage.is_a?(Numeric)
 
       raise_on_invalid_coverage(coverage, "minimum_coverage_by_file")
 
-      @minimum_coverage_by_file = order_default_first(coverage)
+      @minimum_coverage_by_file = coverage
     end
 
     #
@@ -391,7 +391,7 @@ module SimpleCov
     # @param [Symbol] criterion
     #
     def coverage_criterion(criterion = nil)
-      return @coverage_criterion ||= default_coverage_criterion unless criterion
+      return @coverage_criterion ||= primary_coverage unless criterion
 
       raise_if_criterion_unsupported(criterion)
 
@@ -404,21 +404,17 @@ module SimpleCov
       coverage_criteria << criterion
     end
 
-    def primary_coverage(criterion)
-      default_coverage_criterion(criterion)
+    def primary_coverage(criterion = nil)
+      if criterion.nil?
+        @primary_coverage ||= DEFAULT_COVERAGE_CRITERION
+      else
+        raise_if_criterion_disabled(criterion)
+        @primary_coverage = criterion
+      end
     end
 
     def coverage_criteria
-      @coverage_criteria ||= Set[default_coverage_criterion]
-    end
-
-    def default_coverage_criterion(criterion = nil)
-      if criterion.nil?
-        @default_coverage_criterion ||= DEFAULT_COVERAGE_CRITERION
-      else
-        raise_if_criterion_disabled(criterion)
-        @default_coverage_criterion = criterion
-      end
+      @coverage_criteria ||= Set[primary_coverage]
     end
 
     def coverage_criterion_enabled?(criterion)
@@ -467,12 +463,6 @@ module SimpleCov
 
     def minimum_possible_coverage_exceeded(coverage_option)
       warn "The coverage you set for #{coverage_option} is greater than 100%"
-    end
-
-    def order_default_first(coverage)
-      {
-        default_coverage_criterion => coverage[default_coverage_criterion]
-      }.merge(coverage).compact
     end
 
     #

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -256,7 +256,7 @@ describe SimpleCov::Configuration do
           config.primary_coverage :branch
 
           expect(config.coverage_criteria).to contain_exactly :line, :branch
-          expect(config.default_coverage_criterion).to eq :branch
+          expect(config.primary_coverage).to eq :branch
         end
       end
 
@@ -272,7 +272,7 @@ describe SimpleCov::Configuration do
         config.primary_coverage :line
 
         expect(config.coverage_criteria).to contain_exactly :line
-        expect(config.default_coverage_criterion).to eq :line
+        expect(config.primary_coverage).to eq :line
       end
 
       it "can't set primary coverage to arbitrary things" do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -81,7 +81,7 @@ describe SimpleCov::Configuration do
         expect(config.public_send(coverage_setting)).to eq branch: 85.0
       end
 
-      it "sets the right coverage when called withboth line and branch" do
+      it "sets the right coverage when called with both line and branch" do
         config.enable_coverage :branch
         config.public_send(coverage_setting, {branch: 85.0, line: 95.4})
 
@@ -98,6 +98,19 @@ describe SimpleCov::Configuration do
         expect do
           config.public_send(coverage_setting, {unknown: 42})
         end.to raise_error(/unsupported.*unknown/i)
+      end
+
+      context "when primary coverage is set" do
+        before(:each) do
+          config.enable_coverage :branch
+          config.primary_coverage :branch
+        end
+
+        it "sets the right coverage value when called with a number" do
+          config.public_send(coverage_setting, 80)
+
+          expect(config.public_send(coverage_setting)).to eq branch: 80
+        end
       end
     end
 
@@ -232,6 +245,40 @@ describe SimpleCov::Configuration do
         config.enable_for_subprocesses false
 
         expect(config.enable_for_subprocesses).to eq false
+      end
+    end
+
+    describe "#primary_coverage" do
+      context "when branch coverage is enabled" do
+        before(:each) { config.enable_coverage :branch }
+
+        it "can set primary coverage to branch" do
+          config.primary_coverage :branch
+
+          expect(config.coverage_criteria).to contain_exactly :line, :branch
+          expect(config.default_coverage_criterion).to eq :branch
+        end
+      end
+
+      context "when branch coverage is not enabled" do
+        it "cannot set primary coverage to branch " do
+          expect do
+            config.primary_coverage :branch
+          end.to raise_error(/branch.*disabled/i)
+        end
+      end
+
+      it "can set primary coverage to line" do
+        config.primary_coverage :line
+
+        expect(config.coverage_criteria).to contain_exactly :line
+        expect(config.default_coverage_criterion).to eq :line
+      end
+
+      it "can't set primary coverage to arbitrary things" do
+        expect do
+          config.primary_coverage :unknown
+        end.to raise_error(/unsupported.*unknown.*line/i)
       end
     end
   end


### PR DESCRIPTION
This implements #843 to create a `primary_coverage` option, and allows you to set primary coverage to branch. Primary coverage will come first in output, and also will be the default if coverage type is not specified in custom exit behavior.

