### PR TITLE
Improve performance of collate & reduce memorty consumption

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -125,6 +125,7 @@ Metrics/MethodLength:
 
 Metrics/ModuleLength:
   Description: Avoid modules longer than 100 lines of code.
+  Max: 300
   Exclude:
     - "lib/simplecov.rb"
 

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -81,17 +81,13 @@ module SimpleCov
     # information about coverage collation
     #
     def collate(result_filenames, profile = nil, &block)
-      raise "There's no reports to be merged" if result_filenames.empty?
+      raise "There are no reports to be merged" if result_filenames.empty?
 
       initial_setup(profile, &block)
 
-      results = result_filenames.flat_map do |filename|
-        # Re-create each included instance of SimpleCov::Result from the stored run data.
-        Result.from_hash(JSON.parse(File.read(filename)) || {})
-      end
-
       # Use the ResultMerger to produce a single, merged result, ready to use.
-      @result = ResultMerger.merge_and_store(*results)
+      # TODO: Did/does collate ignore old results? It probably shouldn't, right?
+      @result = ResultMerger.merge_and_store(*result_filenames)
 
       run_exit_tasks!
     end

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -63,6 +63,7 @@ module SimpleCov
 
     #
     # Collate a series of SimpleCov result files into a single SimpleCov output.
+    #
     # You can optionally specify configuration with a block:
     #   SimpleCov.collate Dir["simplecov-resultset-*/.resultset.json"]
     #    OR
@@ -86,8 +87,7 @@ module SimpleCov
       initial_setup(profile, &block)
 
       # Use the ResultMerger to produce a single, merged result, ready to use.
-      # TODO: Did/does collate ignore old results? It probably shouldn't, right?
-      @result = ResultMerger.merge_and_store(*result_filenames)
+      @result = ResultMerger.merge_and_store(*result_filenames, ignore_timeout: true)
 
       run_exit_tasks!
     end

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -81,13 +81,17 @@ module SimpleCov
     # available config options, or checkout the README for more in-depth
     # information about coverage collation
     #
-    def collate(result_filenames, profile = nil, &block)
+    # By default `collate` ignores the merge_timeout so all results of all files specified will be
+    # merged together. If you want to honor the merge_timeout then provide the keyword argument
+    # `ignore_timeout: false`.
+    #
+    def collate(result_filenames, profile = nil, ignore_timeout: true, &block)
       raise "There are no reports to be merged" if result_filenames.empty?
 
       initial_setup(profile, &block)
 
       # Use the ResultMerger to produce a single, merged result, ready to use.
-      @result = ResultMerger.merge_and_store(*result_filenames, ignore_timeout: true)
+      @result = ResultMerger.merge_and_store(*result_filenames, ignore_timeout: ignore_timeout)
 
       run_exit_tasks!
     end

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -10,7 +10,7 @@ module SimpleCov
   # defined here are usable from SimpleCov directly. Please check out
   # SimpleCov documentation for further info.
   #
-  module Configuration # rubocop:disable Metrics/ModuleLength
+  module Configuration
     attr_writer :filters, :groups, :formatter, :print_error_status
 
     #

--- a/lib/simplecov/result.rb
+++ b/lib/simplecov/result.rb
@@ -26,7 +26,7 @@ module SimpleCov
     # Initialize a new SimpleCov::Result from given Coverage.result (a Hash of filenames each containing an array of
     # coverage data)
     def initialize(original_result, command_name: nil, created_at: nil)
-      result = adapt_result(original_result)
+      result = original_result
       @original_result = result.freeze
       @command_name = command_name
       @created_at = created_at
@@ -72,10 +72,6 @@ module SimpleCov
       }
     end
 
-    def time_since_creation
-      Time.now - created_at
-    end
-
     # Loads a SimpleCov::Result#to_hash dump
     def self.from_hash(hash)
       hash.map do |command_name, data|
@@ -84,31 +80,6 @@ module SimpleCov
     end
 
   private
-
-    # We changed the format of the raw result data in simplecov, as people are likely
-    # to have "old" resultsets lying around (but not too old so that they're still
-    # considered we can adapt them).
-    # See https://github.com/simplecov-ruby/simplecov/pull/824#issuecomment-576049747
-    def adapt_result(result)
-      if pre_simplecov_0_18_result?(result)
-        adapt_pre_simplecov_0_18_result(result)
-      else
-        result
-      end
-    end
-
-    # pre 0.18 coverage data pointed from file directly to an array of line coverage
-    def pre_simplecov_0_18_result?(result)
-      _key, data = result.first
-
-      data.is_a?(Array)
-    end
-
-    def adapt_pre_simplecov_0_18_result(result)
-      result.transform_values do |line_coverage_data|
-        {"lines" => line_coverage_data}
-      end
-    end
 
     def coverage
       keys = original_result.keys & filenames

--- a/lib/simplecov/result_merger.rb
+++ b/lib/simplecov/result_merger.rb
@@ -137,7 +137,8 @@ module SimpleCov
         synchronize_resultset do
           # Ensure we have the latest, in case it was already cached
           new_resultset = read_resultset
-          # FIXME
+
+          # A single result only ever has one command_name, see `SimpleCov::Result#to_hash`
           command_name, data = result.to_hash.first
           new_resultset[command_name] = data
           File.open(resultset_path, "w+") do |f_|

--- a/spec/fixtures/conditionally_loaded_1.rb
+++ b/spec/fixtures/conditionally_loaded_1.rb
@@ -1,0 +1,3 @@
+# some comment
+puts "wargh"
+puts "wargh 1"

--- a/spec/fixtures/conditionally_loaded_2.rb
+++ b/spec/fixtures/conditionally_loaded_2.rb
@@ -1,0 +1,3 @@
+# some comment
+puts "wargh"
+puts "wargh 2"

--- a/spec/fixtures/parallel_tests.rb
+++ b/spec/fixtures/parallel_tests.rb
@@ -1,0 +1,4 @@
+# foo
+puts "foo"
+# bar
+puts "bar"

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -10,7 +10,11 @@ require "simplecov"
 SimpleCov.coverage_dir("tmp/coverage")
 
 def source_fixture(filename)
-  File.expand_path(File.join(File.dirname(__FILE__), "fixtures", filename))
+  File.join(source_fixture_base_directory, "fixtures", filename)
+end
+
+def source_fixture_base_directory
+  @source_fixture_base_directory ||= File.dirname(__FILE__)
 end
 
 # Taken from http://stackoverflow.com/questions/4459330/how-do-i-temporarily-redirect-stderr-in-ruby

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -236,14 +236,4 @@ describe SimpleCov::Result do
       end
     end
   end
-
-  context "with outdated result format" do
-    it "adapts pre 0.18 results correctly to a new result format" do
-      old_resultset = {source_fixture("three.rb") => [nil, 1, 2]}
-
-      expect(described_class.new(old_resultset).original_result).to eq(
-        source_fixture("three.rb") => {"lines" => [nil, 1, 2]}
-      )
-    end
-  end
 end

--- a/spec/simplecov_spec.rb
+++ b/spec/simplecov_spec.rb
@@ -207,7 +207,7 @@ describe SimpleCov do
         expect do
           glob = Dir.glob("#{resultset_folder}/*.final", File::FNM_DOTMATCH)
           SimpleCov.collate glob
-        end.to raise_error("There's no reports to be merged")
+        end.to raise_error("There are no reports to be merged")
       end
     end
 
@@ -222,7 +222,7 @@ describe SimpleCov do
         end
 
         after do
-          clear_mergeable_reports("result1")
+          clear_mergeable_reports
         end
 
         it "creates a merged report identical to the original" do
@@ -242,7 +242,7 @@ describe SimpleCov do
         end
 
         after do
-          clear_mergeable_reports("result1", "result2")
+          clear_mergeable_reports
         end
 
         it "creates a merged report" do
@@ -264,12 +264,9 @@ describe SimpleCov do
         FileUtils.mv resultset_path, "#{resultset_path}#{name}.final"
       end
 
-      def clear_mergeable_reports(*names)
+      def clear_mergeable_reports
         SimpleCov.clear_result
-        SimpleCov::ResultMerger.clear_resultset
-        FileUtils.rm resultset_path
-        FileUtils.rm "#{resultset_path}.lock"
-        names.each { |name| FileUtils.rm "#{resultset_path}#{name}.final" }
+        FileUtils.rm Dir.glob("#{resultset_path}*")
       end
     end
   end


### PR DESCRIPTION
Draft to get early feedback! (cc: @deivid-rodriguez ? :D ) So Todos and fixmes are intended and will either get resolved or turned into tickets.

I'm worried about breaking things, as the work to move my [quick performance hack](https://github.com/simplecov-ruby/simplecov/compare/collate-plus-plus?expand=1) to main line code was more involved than I had hoped.

I haven't measured this again but memory consumption and speed gains were massive with the initial spike. Perf was ~2x for my smaller sample set and it allowed the big sample set to do its thing at all (I killed it at 12GB memory consumption).

------------------------------------------------------

We used to read all files into memory - which gets too much if
someone runs a massively parallel CI because 400 * 10MB is still
~4GB and that's just pure file size and we do a lot more with it.

Breaks the interface of ResultMerger.merge_and_store but it's not
intended as a public interface. Will leave a note in the Changelog
anyhow.

What is attempted to do top leve is perhaps easier to see when
looking at the spike code: https://github.com/simplecov-ruby/simplecov/compare/collate-plus-plus?expand=1

Changes go further than just not reading all files in at once,
during the merge process we also operate on the raw file structure
as opposed to creating SimpleCov::Result. Creating SimpleCov::Result
comes with a lot of overhead, notably reading in all source files. So,
that's even worse doing ~400 times in a large code base.

There's more optimization potential for cases like these which
I'll open a ticket about but notably:
* Potentially don't create SimpleCov::Result at all until we really
  produce results (just dump the raw coverage more or less)
* allow running without a formatter as only the last one really
  needs the formatter