### PR TITLE
Fix minimum_coverage_by_file check & prep 0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.21.1 (2021-01-04)
+==========
+
+## Bugfixes
+* `minimum_coverage_by_file` works again as expected (errored out before 😱)
+
 0.21.0 (2021-01-03)
 ==========
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    simplecov (0.21.0)
+    simplecov (0.21.1)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)

--- a/features/minimum_coverage_by_file.feature
+++ b/features/minimum_coverage_by_file.feature
@@ -1,49 +1,33 @@
 @test_unit @config
 Feature:
 
-  Exit code should be non-zero if the overall coverage is below the
-  minimum_coverage threshold.
+  Exit code should be non-zero if the coverage of any one file is below the configured value.
 
   Background:
     Given I'm working on the project "faked_project"
 
-  Scenario: It fails against too high coverage
+  Scenario: slightly under minimum coverage by file
     Given SimpleCov for Test/Unit is configured with:
       """
       require 'simplecov'
       SimpleCov.start do
         add_filter 'test.rb'
-        minimum_coverage 90
+        minimum_coverage_by_file 75.01
       end
       """
 
     When I run `bundle exec rake test`
     Then the exit status should not be 0
-    And the output should contain "Line coverage (88.09%) is below the expected minimum coverage (90.00%)."
+    And the output should contain "Line coverage by file (75.00%) is below the expected minimum coverage (75.01%)."
     And the output should contain "SimpleCov failed with exit 2"
 
-  Scenario: It fails if it's just 0.01% too low
+  Scenario: Just passing it
     Given SimpleCov for Test/Unit is configured with:
       """
       require 'simplecov'
       SimpleCov.start do
         add_filter 'test.rb'
-        minimum_coverage 88.10
-      end
-      """
-
-    When I run `bundle exec rake test`
-    Then the exit status should not be 0
-    And the output should contain "Line coverage (88.09%) is below the expected minimum coverage (88.10%)."
-    And the output should contain "SimpleCov failed with exit 2"
-
-  Scenario: It passes when it is exactly the coverage
-    Given SimpleCov for Test/Unit is configured with:
-      """
-      require 'simplecov'
-      SimpleCov.start do
-        add_filter 'test.rb'
-        minimum_coverage 88.09
+        minimum_coverage_by_file 75
       end
       """
 
@@ -58,14 +42,14 @@ Feature:
       SimpleCov.start do
         add_filter 'test.rb'
         enable_coverage :branch
-        minimum_coverage line: 90, branch: 80
+        minimum_coverage_by_file line: 90, branch: 70
       end
       """
 
     When I run `bundle exec rake test`
     Then the exit status should not be 0
-    And the output should contain "Line coverage (88.09%) is below the expected minimum coverage (90.00%)."
-    And the output should contain "Branch coverage (50.00%) is below the expected minimum coverage (80.00%)."
+    And the output should contain "Line coverage by file (80.00%) is below the expected minimum coverage (90.00%)."
+    And the output should contain "Branch coverage by file (50.00%) is below the expected minimum coverage (70.00%)."
     And the output should contain "SimpleCov failed with exit 2"
 
   @branch_coverage
@@ -77,12 +61,12 @@ Feature:
         add_filter 'test.rb'
         enable_coverage :branch
         primary_coverage :branch
-        minimum_coverage 80
+        minimum_coverage_by_file 70
       end
       """
 
     When I run `bundle exec rake test`
     Then the exit status should not be 0
-    And the output should contain "Branch coverage (50.00%) is below the expected minimum coverage (80.00%)."
+    And the output should contain "Branch coverage by file (50.00%) is below the expected minimum coverage (70.00%)."
     And the output should not contain "Line coverage"
     And the output should contain "SimpleCov failed with exit 2"

--- a/lib/simplecov/exit_codes/minimum_coverage_by_file_check.rb
+++ b/lib/simplecov/exit_codes/minimum_coverage_by_file_check.rb
@@ -15,7 +15,7 @@ module SimpleCov
       def report
         minimum_violations.each do |violation|
           $stderr.printf(
-            "%<criterion>s coverage (%<covered>.2f%%) is below the expected minimum coverage (%<minimum_coverage>.2f%%).\n",
+            "%<criterion>s coverage by file (%<covered>.2f%%) is below the expected minimum coverage (%<minimum_coverage>.2f%%).\n",
             covered: SimpleCov.round_coverage(violation.fetch(:actual)),
             minimum_coverage: violation.fetch(:minimum_expected),
             criterion: violation.fetch(:criterion).capitalize
@@ -40,11 +40,11 @@ module SimpleCov
 
       def compute_minimum_coverage_data
         minimum_coverage_by_file.flat_map do |criterion, expected_percent|
-          result.coverage_statistics_by_file[criterion].map do |actual_percent|
+          result.coverage_statistics_by_file.fetch(criterion).map do |actual_coverage|
             {
               criterion: criterion,
               minimum_expected: expected_percent,
-              actual: SimpleCov.round_coverage(actual_percent)
+              actual: SimpleCov.round_coverage(actual_coverage.percent)
             }
           end
         end

--- a/lib/simplecov/file_list.rb
+++ b/lib/simplecov/file_list.rb
@@ -106,8 +106,8 @@ module SimpleCov
 
     def compute_coverage_statistics_by_file
       @files.each_with_object(line: [], branch: []) do |file, together|
-        together[:line] << file.coverage_statistics[:line]
-        together[:branch] << file.coverage_statistics[:branch] if SimpleCov.branch_coverage?
+        together[:line] << file.coverage_statistics.fetch(:line)
+        together[:branch] << file.coverage_statistics.fetch(:branch) if SimpleCov.branch_coverage?
       end
     end
 

--- a/lib/simplecov/version.rb
+++ b/lib/simplecov/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SimpleCov
-  VERSION = "0.21.0"
+  VERSION = "0.21.1"
 end

--- a/spec/exit_codes/minimum_coverage_by_file_check_spec.rb
+++ b/spec/exit_codes/minimum_coverage_by_file_check_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "helper"
+
+RSpec.describe SimpleCov::ExitCodes::MinimumCoverageByFileCheck do
+  let(:result) do
+    instance_double(SimpleCov::Result, coverage_statistics_by_file: stats)
+  end
+  let(:stats) do
+    {
+      line: [SimpleCov::CoverageStatistics.new(covered: 8, missed: 2)]
+    }
+  end
+
+  subject { described_class.new(result, minimum_coverage_by_file) }
+
+  context "all files passing requirements" do
+    let(:minimum_coverage_by_file) { {line: 80} }
+
+    it "passes" do
+      expect(subject).not_to be_failing
+    end
+  end
+
+  context "one file violating requirements" do
+    let(:minimum_coverage_by_file) { {line: 90} }
+
+    it "fails" do
+      p minimum_coverage_by_file
+      expect(subject).to be_failing
+    end
+  end
+end


### PR DESCRIPTION
minimum_coverage_by_file was a gaping hole in the test suite,
which is now partially remedied through rather thorough cucumber
scenarios and 2 small unit tests that should be expanded on in
the future.

On the negative side: This will inconvenince some people. On the
positive side stuffed another hole in the test suite towards a
better future :D Also it was reported very soon thanks to @iMacTia

Fixes #965