### PR TITLE
Bugfix maximum coverage drop with old .last_run file

### DIFF
--- a/features/maximum_coverage_drop.feature
+++ b/features/maximum_coverage_drop.feature
@@ -145,6 +145,7 @@ Feature:
       require 'simplecov'
       SimpleCov.start do
         add_filter 'test.rb'
+        maximum_coverage_drop 0
       end
       """
     And the file "coverage/.last_run.json" with:

--- a/lib/simplecov/exit_codes/maximum_coverage_drop_check.rb
+++ b/lib/simplecov/exit_codes/maximum_coverage_drop_check.rb
@@ -62,7 +62,7 @@ module SimpleCov
       def last_coverage(criterion)
         last_coverage_percent = last_run[:result][criterion]
 
-        if !last_coverage_percent && criterion == "line"
+        if !last_coverage_percent && criterion == :line
           last_run[:result][:covered_percent]
         else
           last_coverage_percent


### PR DESCRIPTION
When `.last_run.json` contains the result key `covered_percent` from a run with a previous version of Simplecov and exit condition `refuse_coverage_drop` or config `maximum_coverage_drop X` is configured it was erroring with 
```
maximum_coverage_drop_check.rb:54:in `block in compute_coverage_drop_data': undefined method `-' for nil:NilClass (NoMethodError)
```
as the criterion is a symbol and not a string as the conditional on line 65 would suggest.  

for more details see #967