### PR TITLE
Fix error in jruby CI job via gem upgrades

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,9 +74,9 @@ GEM
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
     diff-lcs (1.3)
-    docile (1.3.4)
-    ffi (1.13.1)
-    ffi (1.13.1-java)
+    docile (1.3.5)
+    ffi (1.14.2)
+    ffi (1.14.2-java)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
@@ -100,10 +100,6 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry (0.13.1-java)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-      spoon (~> 0.0)
     public_suffix (4.0.6)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -139,8 +135,6 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
-    spoon (0.0.6)
-      ffi
     sys-uname (1.2.2)
       ffi (~> 1.1)
     test-unit (3.3.6)
@@ -182,4 +176,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.2.3
+   2.2.8


### PR DESCRIPTION
I'm semi sure the bug was introduced by bundler upgrade, but
`bundler update pry` then removed the pry-java version but
everything still seems to be working so... :shrug:

Errornous build: https://github.com/simplecov-ruby/simplecov/pull/972/checks?check_run_id=1841431350

PR in which this occured: #972