### PR TITLE
Unify windows and bash .gitignore addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,6 @@ Getting started
    are not tracked by Git (optional):
 
    ```
-   echo "coverage" >> .gitignore
-   ```
-   Or if you use Windows:
-   ```
    echo coverage >> .gitignore
    ```
 


### PR DESCRIPTION
Both bash and cmd do not require quotes around echo statements
Unify the command to add simplicity to README