### PR TITLE
Reduce memory usage while generating report

### DIFF
--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -18,7 +18,7 @@ module SimpleCov
 
     # The path to this source file relative to the projects directory
     def project_filename
-      @filename.sub(Regexp.new("^#{Regexp.escape(SimpleCov.root)}"), "")
+      @filename.delete_prefix(SimpleCov.root)
     end
 
     # The source code for this file. Aliased as :source
@@ -217,7 +217,13 @@ module SimpleCov
       # simplecov-html to have encoding shenaningans in one place. See #866
       # also setting these option on `file.set_encoding` doesn't seem to work
       # properly so it has to be done here.
-      file_lines.each { |line| line.encode!("UTF-8", invalid: :replace, undef: :replace) }
+      file_lines.each do |line|
+        if line.encoding == Encoding::UTF_8
+          line
+        else
+          line.encode!("UTF-8", invalid: :replace, undef: :replace)
+        end
+      end
     end
 
     def build_lines
@@ -238,7 +244,7 @@ module SimpleCov
     end
 
     def lines_strength
-      lines.map(&:coverage).compact.reduce(:+)
+      lines.sum { |line| line.coverage.to_i }
     end
 
     # Warning to identify condition from Issue #56


### PR DESCRIPTION
It was tested on `rubocop`s codebase.
```
▶ pwd
/Users/fatkodima/Desktop/oss/rubocop
▶ cloc --include-lang=Ruby .
    1555 text files.
    1555 unique files.
     235 files ignored.

github.com/AlDanial/cloc v 1.90  T=1.75 s (757.4 files/s, 122769.7 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
Ruby                          1323          30786          24683         158986
-------------------------------------------------------------------------------
SUM:                          1323          30786          24683         158986
-------------------------------------------------------------------------------
```

## CPU
### Before
```
▶ stackprof tmp/stackprof-before.dump --limit 20
==================================
  Mode: cpu(1000)
  Samples: 3538 (2.08% miss rate)
  GC: 438 (12.38%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1630  (46.1%)         670  (18.9%)     SimpleCov::Formatter::HTMLFormatter#formatted_source_file
       738  (20.9%)         598  (16.9%)     SimpleCov::Formatter::HTMLFormatter#template  <==========
       741  (20.9%)         469  (13.3%)     SimpleCov::SourceFile#load_source
       230   (6.5%)         230   (6.5%)     (sweeping)
       208   (5.9%)         208   (5.9%)     (marking)
      2970  (83.9%)         194   (5.5%)     SimpleCov::Formatter::HTMLFormatter#format
       142   (4.0%)         142   (4.0%)     SimpleCov::SourceFile#ensure_remove_undefs
       136   (3.8%)         136   (3.8%)     SimpleCov::SourceFile::Line#skipped?
       271   (7.7%)         128   (3.6%)     SimpleCov::SourceFile#read_lines
       101   (2.9%)         101   (2.9%)     SimpleCov::SourceFile::Line#initialize
        93   (2.6%)          93   (2.6%)     SimpleCov::Formatter::HTMLFormatter#branchable_result?
      1006  (28.4%)          86   (2.4%)     SimpleCov::SourceFile#lines_strength
       116   (3.3%)          54   (1.5%)     SimpleCov::Result#initialize
        53   (1.5%)          53   (1.5%)     SimpleCov::LinesClassifier.no_cov_line
        96   (2.7%)          32   (0.9%)     ERB::Compiler::SimpleScanner#scan
        32   (0.9%)          32   (0.9%)     SimpleCov::SourceFile#project_filename
        32   (0.9%)          31   (0.9%)     ERB::Compiler::Buffer#close
        75   (2.1%)          22   (0.6%)     SimpleCov::LinesClassifier.no_cov_line?
        20   (0.6%)          20   (0.6%)     FileUtils::Entry_#copy_file
       550  (15.5%)          19   (0.5%)     SimpleCov::Formatter::HTMLFormatter#covered_percent
```

### After
```
▶ stackprof tmp/stackprof-after.dump --limit 20
==================================
  Mode: cpu(1000)
  Samples: 2157 (3.23% miss rate)
  GC: 450 (20.86%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       771  (35.7%)         566  (26.2%)     SimpleCov::Formatter::HTMLFormatter#formatted_source_file
       452  (21.0%)         392  (18.2%)     SimpleCov::SourceFile#load_source
       235  (10.9%)         235  (10.9%)     (sweeping)
      1606  (74.5%)         229  (10.6%)     SimpleCov::Formatter::HTMLFormatter#format
       214   (9.9%)         214   (9.9%)     (marking)
       128   (5.9%)         128   (5.9%)     SimpleCov::Formatter::HTMLFormatter#branchable_result?
        95   (4.4%)          95   (4.4%)     SimpleCov::SourceFile::Line#skipped?
        86   (4.0%)          68   (3.2%)     SimpleCov::Result#initialize
        60   (2.8%)          60   (2.8%)     SimpleCov::SourceFile#read_lines
        27   (1.3%)          27   (1.3%)     SimpleCov::LinesClassifier.no_cov_line
        48   (2.2%)          21   (1.0%)     SimpleCov::LinesClassifier.no_cov_line?
        20   (0.9%)          20   (0.9%)     SimpleCov::SourceFile::Line#initialize
        17   (0.8%)          16   (0.7%)     SimpleCov::Formatter::HTMLFormatter#covered_percent
        12   (0.6%)          12   (0.6%)     FileUtils::Entry_#copy_file
         8   (0.4%)           8   (0.4%)     JSON.parse
         5   (0.2%)           5   (0.2%)     JSON.generate
       528  (24.5%)           4   (0.2%)     SimpleCov::SourceFile#lines_strength
        28   (1.3%)           4   (0.2%)     SimpleCov::SourceFile::Line#missed?
         3   (0.1%)           3   (0.1%)     SimpleCov::Formatter::HTMLFormatter#shortened_filename
         3   (0.1%)           3   (0.1%)     SimpleCov::Formatter::HTMLFormatter#id
```

## Memory
### Before
```
Total allocated: 470.18 MB (3001836 objects)
Total retained:  41.95 MB (448582 objects)

allocated memory by gem
-----------------------------------
 222.26 MB  other
 153.65 MB  simplecov/lib
  88.99 MB  lib
   5.27 MB  simplecov-html/lib

allocated memory by file
-----------------------------------
 222.26 MB  (erb)
 142.08 MB  /Users/fatkodima/Desktop/oss/simplecov/lib/simplecov/source_file.rb
  69.30 MB  /Users/fatkodima/.asdf/installs/ruby/2.7.4/lib/ruby/2.7.0/erb.rb
  19.62 MB  /Users/fatkodima/.asdf/installs/ruby/2.7.4/lib/ruby/2.7.0/json/common.rb
   6.82 MB  /Users/fatkodima/Desktop/oss/simplecov/lib/simplecov/result_merger.rb
   5.27 MB  /Users/fatkodima/Desktop/oss/simplecov-html/lib/simplecov-html.rb
   3.59 MB  /Users/fatkodima/Desktop/oss/simplecov/lib/simplecov.rb
 546.01 kB  /Users/fatkodima/Desktop/oss/simplecov/lib/simplecov/result_adapter.rb
....
```

### After
```
Total allocated: 323.66 MB (1887343 objects)
Total retained:  41.95 MB (448582 objects)

allocated memory by gem
-----------------------------------
 221.27 MB  other
  70.41 MB  simplecov/lib
  28.60 MB  lib
   3.37 MB  simplecov-html/lib

allocated memory by file
-----------------------------------
 221.27 MB  (erb)
  62.24 MB  /Users/fatkodima/Desktop/oss/simplecov/lib/simplecov/source_file.rb
  16.90 MB  /Users/fatkodima/.asdf/installs/ruby/2.7.4/lib/ruby/2.7.0/json/common.rb
  11.62 MB  /Users/fatkodima/.asdf/installs/ruby/2.7.4/lib/ruby/2.7.0/erb.rb
   3.59 MB  /Users/fatkodima/Desktop/oss/simplecov/lib/simplecov.rb
   3.42 MB  /Users/fatkodima/Desktop/oss/simplecov/lib/simplecov/result_merger.rb
   3.37 MB  /Users/fatkodima/Desktop/oss/simplecov-html/lib/simplecov-html.rb
 546.01 kB  /Users/fatkodima/Desktop/oss/simplecov/lib/simplecov/result_adapter.rb
...
```

## CPU time
### Before
```
Coverage report generated for RSpec to /Users/fatkodima/Desktop/oss/rubocop/coverage. 65194 / 65652 LOC (99.3%) covered.
Finished in 5.1 seconds
```

### After
```
Coverage report generated for RSpec to /Users/fatkodima/Desktop/oss/rubocop/coverage. 65194 / 65652 LOC (99.3%) covered.
Finished in 3.3 seconds
```

Second part of the change: https://github.com/simplecov-ruby/simplecov-html/pull/114