### PR TITLE
CI: Use bundler-cache, collapse build steps

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.2, jruby-9.3]
+        ruby: [2.5, 2.6, 2.7, '3.0', jruby-9.2, jruby-9.3]
 
     env:
       BUNDLE_WITHOUT: "benchmark"

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -8,18 +8,23 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.5.8, 2.6.6, 2.7.2, 3.0.0, jruby-9.2.20.1]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.2, jruby-9.3]
+
+    env:
+      BUNDLE_WITHOUT: "benchmark"
+      JRUBY_OPTS: "--debug"
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get sqlite for Rails test projects
+        run: sudo apt-get install libsqlite3-dev
 
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - name: Get sqlite for Rails test projects
-        run: sudo apt-get install libsqlite3-dev
+          bundler-cache: true # 'bundle install' and cache
 
       - name: Get the newest rubygems version to rid ourselves of warnings
         run: gem update --system --no-document
@@ -32,10 +37,5 @@ jobs:
           bundle config set --local without benchmark
           bundle install --jobs=3
 
-      - name: Run tests (MRI)
+      - name: Run tests
         run: bundle exec rake
-        if: "!startsWith(matrix.ruby, 'jruby')"
-
-      - name: Run tests (JRuby)
-        run: JRUBY_OPTS=--debug bundle exec rake
-        if: startsWith(matrix.ruby, 'jruby')

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ source "https://rubygems.org"
 # Uncomment this to use development version of html formatter from github
 # gem "simplecov-html", github: "simplecov-ruby/simplecov-html"
 
+gem "matrix"
+
 group :development do
   gem "apparition", "~> 0.6.0"
   gem "aruba", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     ffi (1.15.5-java)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
+    matrix (0.4.2)
     method_source (1.0.0)
     middleware (0.1.0)
     mini_mime (1.1.2)
@@ -102,6 +103,10 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry (0.14.1-java)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      spoon (~> 0.0)
     public_suffix (4.0.6)
     racc (1.6.0)
     racc (1.6.0-java)
@@ -139,6 +144,8 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
+    spoon (0.0.6)
+      ffi
     sys-uname (1.2.2)
       ffi (~> 1.1)
     test-unit (3.5.3)
@@ -170,6 +177,7 @@ DEPENDENCIES
   benchmark-ips
   capybara (~> 3.31)
   cucumber (~> 4.0)
+  matrix
   minitest
   pry
   rake (~> 13.0)


### PR DESCRIPTION
Use the "3.0" (major.minor) way of asking ruby/setup-ruby for the latest known release with that prefix.

Collapse identical steps.

---

This turned into "revamp the CI configuration", and "add a matrix with different versions of Ruby on Rails for different versions of Ruby".

**Update**: I learned that the things had been done, in `main`, and rolled back most of the changes. 