### PR TITLE
Add needed require line for CSV example

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,9 +846,11 @@ When calling SimpleCov.result.format!, it will be invoked with SimpleCov::Format
 
 ## Using multiple formatters
 
-As of SimpleCov 0.9, you can specify multiple result formats:
+As of SimpleCov 0.9, you can specify multiple result formats. Formatters besides the default HTML formatter require separate gems, however.
 
 ```ruby
+require "simplecov-html"
+
 SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::CSVFormatter,


### PR DESCRIPTION
We got confused when trying to use the CSVFormatter and discovered it also required another gem (at least for our version). Thus I suggest adding a clarification as I suggest in this PR. It might also be more clear if the "Multiple formatters" heading was below the "JSON formatter" section.