### PR TITLE
test: Use unreleased version of apparition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ source "https://rubygems.org"
 gem "matrix"
 
 group :development do
-  gem "apparition", "~> 0.6.0"
+  gem "apparition", github: "twalpole/apparition" # LOCKED: When this is released, use a released version https://github.com/twalpole/apparition/pull/79
   gem "aruba", "~> 1.0"
   gem "capybara", "~> 3.31"
   gem "cucumber", "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/twalpole/apparition.git
+  revision: ca86be4d54af835d531dbcd2b86e7b2c77f85f34
+  specs:
+    apparition (0.6.0)
+      capybara (~> 3.13, < 4)
+      websocket-driver (>= 0.6.5)
+
 PATH
   remote: .
   specs:
@@ -17,9 +25,6 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    apparition (0.6.0)
-      capybara (~> 3.13, < 4)
-      websocket-driver (>= 0.6.5)
     aruba (1.1.2)
       bundler (>= 1.17, < 3.0)
       childprocess (>= 2.0, < 5.0)
@@ -172,7 +177,7 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  apparition (~> 0.6.0)
+  apparition!
   aruba (~> 1.0)
   benchmark-ips
   capybara (~> 3.31)


### PR DESCRIPTION
This avoids unnecessary warnings in the test output.

See https://github.com/twalpole/apparition/pull/79