### PR TITLE
Fix incorrect comment on "Gemfile"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 # Uncomment this to use local copy of simplecov-html in development when checked out
-# gem "simplecov-html", path: File.dirname(__FILE__) + "/../simplecov-html"
+# gem "simplecov-html", path: File.join(__dir__, "../simplecov-html")
 
 # Uncomment this to use development version of html formatter from github
 # gem "simplecov-html", github: "simplecov-ruby/simplecov-html"


### PR DESCRIPTION
I uncommented https://github.com/simplecov-ruby/simplecov/blob/v0.21.2/Gemfile#L6 to run test with local copy of simplecov-html ([currently main branch](https://github.com/simplecov-ruby/simplecov-html/tree/5bc5798aefed312abd189baed8a97bf1febfa8d7)).

I saw following:

```
yuya@yoshiyuki|12:09:34|0% bundle
...
yuya@yoshiyuki|12:09:47|0% bundle exec rake
...
Inspecting 108 files
C...........................................................................................................

Offenses:

Gemfile:6:29: C: [Correctable] Style/StringConcatenation: Prefer string interpolation to string concatenation.
gem "simplecov-html", path: File.dirname(__FILE__) + "/../simplecov-html"
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

108 files inspected, 1 offense detected, 1 offense auto-correctable
RuboCop failed!
```

This pull-request fixes it.
