### PR TITLE
[Security] Bumped Rack version to 2.2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     public_suffix (4.0.6)
     racc (1.6.0)
     racc (1.6.0-java)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.1.1)


### PR DESCRIPTION
Rack 2.2.3 suffers from 2 CVEs which are fixed in 2.2.3.1: 
https://github.com/rack/rack/blob/main/CHANGELOG.md#2231---2022-05-27

Signed-off-by: Theo Truong <theotr@amazon.com>