### PR TITLE
Support coverage for eval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ tmp
 .yardoc
 spec/fixtures/coverage
 spec/fixtures/frameworks/coverage
+spec/fixtures/eval_test/coverage
 test_projects/**/coverage

--- a/README.md
+++ b/README.md
@@ -354,6 +354,18 @@ Primary coverage determines what will come in first all output, and the type of 
 
 Note that coverage must first be enabled for non-default coverage types.
 
+## Coverage for eval
+
+You can measure coverage for code that is evaluated by `Kernel#eval`. Supported in CRuby versions 3.2+.
+
+```ruby
+SimpleCov.start do
+  enable_coverage_for_eval
+end
+```
+
+This is typically useful for ERB. Set `ERB#filename=` to make it possible for SimpleCov to trace the original .erb source file.
+
 ## Filters
 
 Filters can be used to remove selected files from your coverage data. By default, a filter is applied that removes all

--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -351,6 +351,8 @@ module SimpleCov
         [lookup_corresponding_ruby_coverage_name(criterion), true]
       end.to_h
 
+      start_arguments[:eval] = true if coverage_for_eval_enabled?
+
       Coverage.start(start_arguments) unless Coverage.running?
     end
 

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -457,7 +457,7 @@ module SimpleCov
       if coverage_for_eval_supported?
         @coverage_for_eval_enabled = true
       else
-        raise "Coverage for eval is not available! Use Ruby 3.2.0 or later"
+        warn "Coverage for eval is not available; Use Ruby 3.2.0 or later"
       end
     end
 

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -444,6 +444,23 @@ module SimpleCov
       coverage_start_arguments_supported? && RUBY_ENGINE != "jruby"
     end
 
+    def coverage_for_eval_supported?
+      require "coverage"
+      defined?(Coverage.supported?) && Coverage.supported?(:eval)
+    end
+
+    def coverage_for_eval_enabled?
+      @coverage_for_eval_enabled ||= false
+    end
+
+    def enable_coverage_for_eval
+      if coverage_for_eval_supported?
+        @coverage_for_eval_enabled = true
+      else
+        raise "Coverage for eval is not available! Use Ruby 3.2.0 or later"
+      end
+    end
+
   private
 
     def raise_if_criterion_disabled(criterion)

--- a/spec/coverage_for_eval_spec.rb
+++ b/spec/coverage_for_eval_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "helper"
+
+RSpec.describe "coverage for eval" do
+  if SimpleCov.coverage_for_eval_supported?
+    around do |test|
+      Dir.chdir(File.join(File.dirname(__FILE__), "fixtures", "eval_test")) do
+        FileUtils.rm_rf("./coverage")
+        test.call
+      end
+    end
+
+    before do
+      @stdout, @stderr, @status = Open3.capture3(command)
+    end
+
+    context "foo" do
+      let(:command) { "ruby eval_test.rb" }
+
+      it "records coverage for erb" do
+        expect(@stdout).to include(" 2 / 3 LOC")
+      end
+    end
+  end
+end

--- a/spec/fixtures/eval_test/eval_test.erb
+++ b/spec/fixtures/eval_test/eval_test.erb
@@ -1,0 +1,5 @@
+<% if 1 + 1 == 2 %>
+  covered
+<% else %>
+  not covered
+<% end %>

--- a/spec/fixtures/eval_test/eval_test.rb
+++ b/spec/fixtures/eval_test/eval_test.rb
@@ -1,0 +1,8 @@
+require "simplecov"
+SimpleCov.enable_coverage_for_eval
+SimpleCov.start "rails"
+
+file = File.join(__dir__, "eval_test.erb")
+erb = ERB.new(File.read(file))
+erb.filename = file
+erb.run


### PR DESCRIPTION
Since Ruby 3.2, coverage.so can measure coverage of code that evaluated by `Kernel#eval`. Typically, this would be useful for ERB.

https://bugs.ruby-lang.org/issues/19008

This change adds a new API for SimpleCov to enable the feature.

```ruby
SimpleCov.start do
  enable_coverage_for_eval
end
```

Here is a sample output:

![image](https://user-images.githubusercontent.com/21557/205423930-6ee3116d-d04b-49c7-91e7-3a0a123c5848.png)

I hope this feature will be released until the release date of Ruby 3.2 (25th in this month).