### PR TITLE
Bump version to 0.22.0, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+0.22.0 (2022-12-23
+==========
+
+## Enhancements
+
+* On Ruby 3.2+, you can now use the new Coverage library feature for `eval` - See https://github.com/simplecov-ruby/simplecov/pull/1037. Thanks [@mame](https://github.com/mame)!
+
+## Bugfixes
+* Fix for making the test suite pass against the upcoming Ruby 3.2 - See https://github.com/simplecov-ruby/simplecov/pull/1035. Thanks [@mame](https://github.com/mame)
+
 0.21.2 (2021-01-09)
 ==========
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    simplecov (0.21.2)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
@@ -148,7 +148,7 @@ GEM
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.3)
+    simplecov_json_formatter (0.1.4)
     spoon (0.0.6)
       ffi
     sys-uname (1.2.2)
@@ -193,4 +193,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.4
+   2.3.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.4)
+    simplecov_json_formatter (0.1.3)
     spoon (0.0.6)
       ffi
     sys-uname (1.2.2)
@@ -193,4 +193,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.26
+   2.3.4

--- a/features/minitest_basic.feature
+++ b/features/minitest_basic.feature
@@ -53,7 +53,7 @@ Feature:
     # version seems to work.
     And I set the environment variables to:
       | variable                     | value   |
-      | SIMPLECOV_NO_REQUIRE_VERSION | 0.21.2 |
+      | SIMPLECOV_NO_REQUIRE_VERSION | 0.22.0 |
 
     When I successfully run `bundle exec rake minitest`
     Then no coverage report should have been generated

--- a/lib/simplecov/version.rb
+++ b/lib/simplecov/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SimpleCov
-  VERSION = "0.21.2"
+  VERSION = "0.22.0"
 end

--- a/test_projects/monorepo/Gemfile.lock
+++ b/test_projects/monorepo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    simplecov (0.20.0)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
@@ -21,7 +21,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
-    docile (1.3.4)
+    docile (1.4.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -36,7 +36,7 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
     simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.2)
+    simplecov_json_formatter (0.1.4)
 
 PLATFORMS
   ruby
@@ -49,4 +49,4 @@ DEPENDENCIES
   simplecov!
 
 BUNDLED WITH
-   2.2.2
+   2.3.26

--- a/test_projects/parallel_tests/Gemfile.lock
+++ b/test_projects/parallel_tests/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    simplecov (0.20.0)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
@@ -10,7 +10,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
-    docile (1.3.4)
+    docile (1.4.0)
     parallel (1.19.2)
     parallel_tests (3.1.0)
       parallel
@@ -28,7 +28,7 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
     simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.2)
+    simplecov_json_formatter (0.1.4)
 
 PLATFORMS
   ruby
@@ -40,4 +40,4 @@ DEPENDENCIES
   simplecov!
 
 BUNDLED WITH
-   2.2.2
+   2.3.26

--- a/test_projects/rails/rspec_rails/Gemfile.lock
+++ b/test_projects/rails/rspec_rails/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    simplecov (0.21.2)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
@@ -173,7 +173,7 @@ GEM
       rspec-support (~> 3.9)
     rspec-support (3.10.0)
     simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.3)
+    simplecov_json_formatter (0.1.4)
     spring (2.1.1)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
@@ -212,7 +212,6 @@ DEPENDENCIES
   byebug
   capybara (>= 3.36.0)
   jbuilder (~> 2.7)
-  public_suffix (= 4.0.7)
   puma (~> 5.0)
   rails (~> 6.1.4)
   rspec-rails


### PR DESCRIPTION
Contains most notably #1035 and #1037, as well as a number of tweaks to rubocop + gitlab actions changes