### PR TITLE
allow Coverage to start when Coverage.running? is not implemented

### DIFF
--- a/lib/simplecov.rb
+++ b/lib/simplecov.rb
@@ -342,7 +342,7 @@ module SimpleCov
       if coverage_start_arguments_supported?
         start_coverage_with_criteria
       else
-        Coverage.start unless Coverage.running?
+        Coverage.start unless coverage_running?
       end
     end
 
@@ -353,7 +353,13 @@ module SimpleCov
 
       start_arguments[:eval] = true if coverage_for_eval_enabled?
 
-      Coverage.start(start_arguments) unless Coverage.running?
+      Coverage.start(start_arguments) unless coverage_running?
+    end
+
+    def coverage_running?
+      # for ruby versions which do not implement Coverage.running?,
+      # Coverage.start may be called multiple times without raising.
+      Coverage.respond_to?(:running?) && Coverage.running?
     end
 
     CRITERION_TO_RUBY_COVERAGE = {


### PR DESCRIPTION
Amends https://github.com/simplecov-ruby/simplecov/pull/1035/commits/1cc7650454fc7c53e7a724941662c3e9d3329ccc from #1035

Another option would be to just call Coverage.start unconditionally and rescue the RuntimeError it now raises when already started.