### PR TITLE
Update Ruby Coverage documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SimpleCov [![Gem Version](https://badge.fury.io/rb/simplecov.svg)](https://badge
   * [Rubygem]
   * [Continuous Integration]
 
-[Coverage]: https://ruby-doc.org/stdlib/libdoc/coverage/rdoc/Coverage.html "API doc for Ruby's Coverage library"
+[Coverage]: https://ruby-doc.org/stdlib/exts/coverage/Coverage.html "API doc for Ruby's Coverage library"
 [Source Code]: https://github.com/simplecov-ruby/simplecov "Source Code @ GitHub"
 [API documentation]: http://rubydoc.info/gems/simplecov/frames "RDoc API Documentation at Rubydoc.info"
 [Configuration]: http://rubydoc.info/gems/simplecov/SimpleCov/Configuration "Configuration options API documentation"


### PR DESCRIPTION
It appears the path to the Coverage module documentation has changed with the latest release of Ruby. The link in the README is currently sending me to a not found page.

This updates the link to provide information on the Coverage module.