### PR TITLE
Replace Kernel.open with IO.popen

### DIFF
--- a/spec/result_merger_spec.rb
+++ b/spec/result_merger_spec.rb
@@ -259,9 +259,7 @@ describe SimpleCov::ResultMerger do
       end
       CODE
 
-      # rubocop:disable Security/Open
-      other_process = open("|ruby -e #{Shellwords.escape(test_script)} 2>/dev/null")
-      # rubocop:enable Security/Open
+      other_process = IO.popen("ruby -e #{Shellwords.escape(test_script)} 2>/dev/null")
 
       SimpleCov::ResultMerger.synchronize_resultset do
         # wait until the child process is going, and then wait some more


### PR DESCRIPTION
Replace `Kernel.open` with `IO.popen` since it's deprecated and will be removed in [future ruby versions](https://github.com/simplecov-ruby/simplecov/actions/runs/6003574534/job/16282314756?pr=1068).