### PR TITLE
Fallback to empty array if branches is missing

### DIFF
--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -272,9 +272,9 @@ module SimpleCov
     #
     def build_branches
       coverage_branch_data = coverage_data.fetch("branches", {})
-      branches = coverage_branch_data.flat_map do |condition, coverage_branches|
+      branches = coverage_branch_data&.flat_map do |condition, coverage_branches|
         build_branches_from(condition, coverage_branches)
-      end
+      end || []
 
       process_skipped_branches(branches)
     end


### PR DESCRIPTION
When I enabled branch coverage in https://github.com/exoego/rspec-openapi/pull/125,  I found this line raises error because of `coverage_branch_data` is `nil`.
Sorry, I was not able to make a minimum repro nor make a test case, but this change is working in rspec-openapi repo.

