### PR TITLE
Run Rubocop only once in CI

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run Rubocop
         run: bundle exec rake rubocop
         # code style is enough to check once (and might even take some time on JRuby)
-        if: matrix.ruby-version != '3.3'
+        if: matrix.ruby-version == '3.3'
 
       - name: Run tests
         run: bundle exec rake test

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -29,13 +29,17 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 
+      - name: Run Rubocop
+        run: bundle exec rake rubocop
+        # code style is enough to check once (and might even take some time on JRuby)
+        if: matrix.ruby-version != '3.3'
+
       - name: Run tests
-        run: bundle exec rake
+        run: bundle exec rake test
         if: matrix.ruby-version != 'truffleruby'
 
-      # Run only `rake spec` on truffleruby, because just `rake` runs `rubocop spec cucumber`.
-      # There is no value to rerun rubocop here.
-      # cucumber fails because it uses an old childprocess which depends on fork.
+      # Run only `rake spec` on truffleruby, because just `rake` runs cucumber
+      # which fails because it uses an old childprocess which depends on fork.
       - name: Run specs (truffleruby)
         run: bundle exec rake spec
         if: matrix.ruby-version == 'truffleruby'

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -28,12 +28,11 @@ jobs:
           bundler-cache: true
 
       - name: Run tests
-        run: bundle exec rake
+        run: bundle exec rake test
         if: matrix.ruby-version != 'truffleruby-head'
 
-      # Run only `rake spec` on truffleruby, because just `rake` runs `rubocop spec cucumber`.
-      # There is no value to rerun rubocop here.
-      # cucumber fails because it uses an old childprocess which depends on fork.
+      # Run only `rake spec` on truffleruby, because just `rake` runs cucumber
+      # which fails because it uses an old childprocess which depends on fork.
       - name: Run specs (truffleruby)
         run: bundle exec rake spec
         if: matrix.ruby-version == 'truffleruby-head'

--- a/Rakefile
+++ b/Rakefile
@@ -29,4 +29,5 @@ Cucumber::Rake::Task.new do |t|
   t.cucumber_opts = %w[--retry 3 --no-strict-flaky]
 end
 
+task test: %i[spec cucumber]
 task default: %i[rubocop spec cucumber]


### PR DESCRIPTION
No need to keep running rubocop, can esp. even be a bit slow on JRuby