### PR TITLE
Unexclude skipped on TruffleRuby test case

### DIFF
--- a/spec/return_codes_spec.rb
+++ b/spec/return_codes_spec.rb
@@ -35,7 +35,8 @@ describe "return codes" do
 
         it "prints a message to STDERR" do
           # https://github.com/oracle/truffleruby/issues/3535
-          skip "fails on truffleruby" if RUBY_ENGINE == "truffleruby" && command.include?("testunit_bad.rb")
+          skip "fails on truffleruby" if RUBY_ENGINE == "truffleruby" && Object::Object::RUBY_ENGINE_VERSION < "24.1" && command.include?("testunit_bad.rb")
+
           expect(@stderr).to match(/stopped.+SimpleCov.+previous.+error/i)
         end
       end


### PR DESCRIPTION
Follow-up for https://github.com/oracle/truffleruby/issues/3535.

Enables a test case in `spec/return_codes_spec.rb` file on `truffleruby-head`.