### PR TITLE
Store and display filename in results

### DIFF
--- a/lib/simplecov/coverage_statistics.rb
+++ b/lib/simplecov/coverage_statistics.rb
@@ -5,15 +5,16 @@ module SimpleCov
   #
   # This is uniform across coverage criteria as they all have:
   #
+  # * filename - the full name of the file
   # * total - how many things to cover there are (total relevant loc/branches)
   # * covered - how many of the coverables are hit
   # * missed - how many of the coverables are missed
   # * percent - percentage as covered/missed
   # * strength - average hits per/coverable (will not exist for one shot lines format)
   class CoverageStatistics
-    attr_reader :total, :covered, :missed, :strength, :percent
+    attr_reader :filename, :total, :covered, :missed, :strength, :percent
 
-    def self.from(coverage_statistics)
+    def self.from(filename:, coverage_statistics:)
       sum_covered, sum_missed, sum_total_strength =
         coverage_statistics.reduce([0, 0, 0.0]) do |(covered, missed, total_strength), file_coverage_statistics|
           [
@@ -25,13 +26,14 @@ module SimpleCov
           ]
         end
 
-      new(covered: sum_covered, missed: sum_missed, total_strength: sum_total_strength)
+      new(filename: filename, covered: sum_covered, missed: sum_missed, total_strength: sum_total_strength)
     end
 
     # Requires only covered, missed and strength to be initialized.
     #
     # Other values are computed by this class.
-    def initialize(covered:, missed:, total_strength: 0.0)
+    def initialize(filename:, covered:, missed:, total_strength: 0.0)
+      @filename = filename
       @covered  = covered
       @missed   = missed
       @total    = covered + missed

--- a/lib/simplecov/exit_codes/minimum_coverage_by_file_check.rb
+++ b/lib/simplecov/exit_codes/minimum_coverage_by_file_check.rb
@@ -14,8 +14,10 @@ module SimpleCov
 
       def report
         minimum_violations.each do |violation|
+          filename = violation.fetch(:filename)
+
           $stderr.printf(
-            "%<criterion>s coverage by file (%<covered>.2f%%) is below the expected minimum coverage (%<minimum_coverage>.2f%%).\n",
+            "%<criterion>s coverage by file (%<covered>.2f%%) is below the expected minimum coverage (%<minimum_coverage>.2f%%): #{filename}\n",
             covered: SimpleCov.round_coverage(violation.fetch(:actual)),
             minimum_coverage: violation.fetch(:minimum_expected),
             criterion: violation.fetch(:criterion).capitalize
@@ -42,6 +44,7 @@ module SimpleCov
         minimum_coverage_by_file.flat_map do |criterion, expected_percent|
           result.coverage_statistics_by_file.fetch(criterion).map do |actual_coverage|
             {
+              filename: actual_coverage.filename,
               criterion: criterion,
               minimum_expected: expected_percent,
               actual: SimpleCov.round_coverage(actual_coverage.percent)

--- a/lib/simplecov/file_list.rb
+++ b/lib/simplecov/file_list.rb
@@ -105,16 +105,31 @@ module SimpleCov
   private
 
     def compute_coverage_statistics_by_file
-      @files.each_with_object(line: [], branch: []) do |file, together|
+      @files.each_with_object(filename: [], line: [], branch: []) do |file, together|
+        together[:filename] << file.filename
         together[:line] << file.coverage_statistics.fetch(:line)
         together[:branch] << file.coverage_statistics.fetch(:branch) if SimpleCov.branch_coverage?
       end
     end
 
     def compute_coverage_statistics
-      coverage_statistics = {line: CoverageStatistics.from(coverage_statistics_by_file[:line])}
-      coverage_statistics[:branch] = CoverageStatistics.from(coverage_statistics_by_file[:branch]) if SimpleCov.branch_coverage?
+      coverage_statistics = {line: line_coverage_statistics}
+      coverage_statistics[:branch] = branch_coverage_statistics if SimpleCov.branch_coverage?
       coverage_statistics
+    end
+
+    def line_coverage_statistics
+      CoverageStatistics.from(
+        filename: coverage_statistics_by_file[:filename],
+        coverage_statistics: coverage_statistics_by_file[:line]
+      )
+    end
+
+    def branch_coverage_statistics
+      CoverageStatistics.from(
+        filename: coverage_statistics_by_file[:filename],
+        coverage_statistics: coverage_statistics_by_file[:branch]
+      )
     end
   end
 end

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -336,6 +336,7 @@ module SimpleCov
     def line_coverage_statistics
       {
         line: CoverageStatistics.new(
+          filename: filename,
           total_strength: lines_strength,
           covered:  covered_lines.size,
           missed:   missed_lines.size
@@ -346,6 +347,7 @@ module SimpleCov
     def branch_coverage_statistics
       {
         branch: CoverageStatistics.new(
+          filename: filename,
           covered: covered_branches.size,
           missed:  missed_branches.size
         )


### PR DESCRIPTION
I'd like to see filenames in my output when line or branch coverage fails and this change appears to work.

I'm using the `minimum_coverage_by_file` option in my test helper, but the current output doesn't seem helpful on it's own, especially in a CI context.

Maybe the intention is to force people to use the UI locally to find the files that need to be covered? But I think it would be helpful to my team if they could immediately see which file has an issue.

I will add tests to cover this, just wondering:

1) Is this something that has a chance of being merged into the main repo?
2) Am I totally on the wrong track with how to implement this? Is there a way to access the filename that I overlooked?

Example output:

```
Finished in 4.044369s, 82.5840 runs/s, 240.0869 assertions/s.
334 runs, 971 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /Users/ryan/Code/ryanstrickler/client/coverage. 1066 / 1103 LOC (96.65%) covered.
Line coverage by file (0.00%) is below the expected minimum coverage (70.00%): /Users/ryan/Code/ryanstrickler/client/app/models/order_preview.rb
Branch coverage by file (0.00%) is below the expected minimum coverage (50.00%): /Users/ryan/Code/ryanstrickler/client/app/models/material_request_category.rb
```

If this is something that's been tried or shot down before, my apologies. I searched the repo and didn't see anything obviously related.

This is actually one of the first open-source PRs I've ever submitted, so be gentle. 😆