### PR TITLE
Technical/Fix documentation formatters usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -861,10 +861,10 @@ As of SimpleCov 0.9, you can specify multiple result formats. Formatters besides
 ```ruby
 require "simplecov-html"
 
-SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::CSVFormatter,
-])
+]
 ```
 
 ## JSON formatter


### PR DESCRIPTION
This PR is created in order to have up to dated documentation. Following to the code under the hood:

https://github.com/simplecov-ruby/simplecov/blob/903655419edee0abb4cfdbb9d0d09d0524c2abab/lib/simplecov/configuration.rb#L110-L112

For `SimpleCov.formatters` call examples in the current documentation we need to use array of formatters:

```ruby
SimpleCov.formatters = [
  SimpleCov::Formatter::HTMLFormatter,
  SimpleCov::Formatter::CSVFormatter,
]
```

instead of instance of `SimpleCov::Formatter::MultiFormatter`:

```ruby
SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
  SimpleCov::Formatter::HTMLFormatter,
  SimpleCov::Formatter::CSVFormatter,
])
```