### PR TITLE
add line and branch coverage output expectation

### DIFF
--- a/features/branch_coverage.feature
+++ b/features/branch_coverage.feature
@@ -15,7 +15,15 @@ Feature:
       end
       """
     When I open the coverage report generated with `bundle exec rspec spec`
-    Then I should see the groups:
+    Then the output should contain:
+      """
+      56 / 61 LOC (91.8%) covered
+      """
+    And the output should contain:
+      """
+      2 / 4 branches (50.0%) covered
+      """
+    And I should see the groups:
       | name      | coverage | files |
       | All Files | 91.8%    | 7     |
     And I should see a line coverage summary of 56/61


### PR DESCRIPTION
The standard output is missing branch coverage when branch coverage is enabled.  Line 22 of the updated scenario (the branch coverage report) fails right now because the [simplecov-html gem](https://rubygems.org/gems/simplecov-html/versions/0.12.3) has not been updated to include [the code that prints it](https://github.com/simplecov-ruby/simplecov-html/blame/013f559b58a1dc0f4a3f65b87d6ebb8caa24c289/lib/simplecov-html.rb#L42) (line 42).