### PR TITLE
minimum_coverage_by_file now prints the name of the violating file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
+0.22.1 (YYYY-MM-DD)
+==========
+
+## Enhancements
+* `minimum_coverage_by_file` prints the name of the violating file. - (@philipritchey)[https://github.com/philipritchey]
+
 0.22.0 (2022-12-23)
 ==========
 
 ## Enhancements
-
 * On Ruby 3.2+, you can now use the new Coverage library feature for `eval` - See https://github.com/simplecov-ruby/simplecov/pull/1037. Thanks [@mame](https://github.com/mame)!
 
 ## Bugfixes

--- a/features/minimum_coverage_by_file.feature
+++ b/features/minimum_coverage_by_file.feature
@@ -18,7 +18,7 @@ Feature:
 
     When I run `bundle exec rake test`
     Then the exit status should not be 0
-    And the output should contain "Line coverage by file (75.00%) is below the expected minimum coverage (75.01%)."
+    And the output should contain "Line coverage by file (75.00%) is below the expected minimum coverage (75.01%) in framework_specific.rb."
     And the output should contain "SimpleCov failed with exit 2"
 
   Scenario: Just passing it
@@ -48,8 +48,8 @@ Feature:
 
     When I run `bundle exec rake test`
     Then the exit status should not be 0
-    And the output should contain "Line coverage by file (80.00%) is below the expected minimum coverage (90.00%)."
-    And the output should contain "Branch coverage by file (50.00%) is below the expected minimum coverage (70.00%)."
+    And the output should contain "Line coverage by file (80.00%) is below the expected minimum coverage (90.00%) in some_class.rb."
+    And the output should contain "Branch coverage by file (50.00%) is below the expected minimum coverage (70.00%) in some_class.rb."
     And the output should contain "SimpleCov failed with exit 2"
 
   @branch_coverage
@@ -67,6 +67,6 @@ Feature:
 
     When I run `bundle exec rake test`
     Then the exit status should not be 0
-    And the output should contain "Branch coverage by file (50.00%) is below the expected minimum coverage (70.00%)."
+    And the output should contain "Branch coverage by file (50.00%) is below the expected minimum coverage (70.00%) in some_class.rb."
     And the output should not contain "Line coverage"
     And the output should contain "SimpleCov failed with exit 2"

--- a/lib/simplecov/exit_codes/minimum_coverage_by_file_check.rb
+++ b/lib/simplecov/exit_codes/minimum_coverage_by_file_check.rb
@@ -15,10 +15,11 @@ module SimpleCov
       def report
         minimum_violations.each do |violation|
           $stderr.printf(
-            "%<criterion>s coverage by file (%<covered>.2f%%) is below the expected minimum coverage (%<minimum_coverage>.2f%%).\n",
+            "%<criterion>s coverage by file (%<covered>.2f%%) is below the expected minimum coverage (%<minimum_coverage>.2f%%) in %<filename>s.\n",
             covered: SimpleCov.round_coverage(violation.fetch(:actual)),
             minimum_coverage: violation.fetch(:minimum_expected),
-            criterion: violation.fetch(:criterion).capitalize
+            criterion: violation.fetch(:criterion).capitalize,
+            filename: File.basename(violation.fetch(:filename))
           )
         end
       end
@@ -40,11 +41,12 @@ module SimpleCov
 
       def compute_minimum_coverage_data
         minimum_coverage_by_file.flat_map do |criterion, expected_percent|
-          result.coverage_statistics_by_file.fetch(criterion).map do |actual_coverage|
+          result.files.collect(&:filename).zip(result.coverage_statistics_by_file.fetch(criterion)).map do |filename, actual_coverage|
             {
               criterion: criterion,
               minimum_expected: expected_percent,
-              actual: SimpleCov.round_coverage(actual_coverage.percent)
+              actual: SimpleCov.round_coverage(actual_coverage.percent),
+              filename: filename
             }
           end
         end

--- a/spec/exit_codes/minimum_coverage_by_file_check_spec.rb
+++ b/spec/exit_codes/minimum_coverage_by_file_check_spec.rb
@@ -6,12 +6,24 @@ RSpec.describe SimpleCov::ExitCodes::MinimumCoverageByFileCheck do
   subject { described_class.new(result, minimum_coverage_by_file) }
 
   let(:result) do
-    instance_double(SimpleCov::Result, coverage_statistics_by_file: stats)
+    instance_double(SimpleCov::Result, coverage_statistics_by_file: stats, files: files)
   end
   let(:stats) do
     {
       line: [SimpleCov::CoverageStatistics.new(covered: 8, missed: 2)]
     }
+  end
+  let(:files) do
+    SimpleCov::FileList.new(
+      [
+        SimpleCov::SourceFile.new(
+          "foo.rb",
+          {
+            "lines" => [nil, 8, 6, 7, 5, 3, 0, 9, 0, 3, 5, nil]
+          }
+        )
+      ]
+    )
   end
 
   context "all files passing requirements" do


### PR DESCRIPTION
when minimum coverage by file is set, output used to (*currently*) look like:

```
Line coverage by file (83.33%) is below the expected minimum coverage (90.00%).
Branch coverage by file (77.77%) is below the expected minimum coverage (90.00%).
```

now, with `in <filename>` at the end of the line,  it (*could*) looks like:
```
Line coverage by file (83.33%) is below the expected minimum coverage (90.00%) in foo.rb.
Branch coverage by file (77.77%) is below the expected minimum coverage (90.00%) in foo.rb.
```

