### PR TITLE
Bring Ruby 2.7 support back

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - run: rm Gemfile.lock
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -13,6 +13,7 @@ jobs:
 
       matrix:
         ruby-version:
+          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
     - "tmp/**/*"
     - "vendor/bundle/**/*"
     - "vendor/bundle/**/.*"
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 2.7
   NewCops: enable
   # we might wanna adopt rspec and rake but it's a bit annoying for now
   SuggestExtensions: false

--- a/README.md
+++ b/README.md
@@ -889,7 +889,7 @@ SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
 
 ## Ruby version compatibility
 
-SimpleCov is built in [Continuous Integration] on Ruby 3.0+ as well as JRuby 9.3+.
+SimpleCov is built in [Continuous Integration] on Ruby 2.7+ as well as JRuby 9.3+.
 
 Note for JRuby => You need to pass JRUBY_OPTS="--debug" or create .jrubyrc and add debug.fullTrace=true
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,12 +13,12 @@ require "simplecov"
 
 # Monkey-patching Capybara::DSL if Capybara::DSLRSpecProxyInstaller has no `extended` hook
 unless Module.new.extend(RSpec::Matchers).extend(Capybara::DSL).singleton_class.ancestors.include?(Capybara::RSpecMatcherProxies)
-  Capybara::DSL.extend(Module.new {
+  Capybara::DSL.extend(Module.new do
     def extended(base)
-      base.extend(::Capybara::RSpecMatcherProxies) if defined?(::RSpec::Matchers) && base.is_a?(::RSpec::Matchers)
+      base.extend(Capybara::RSpecMatcherProxies) if defined?(RSpec::Matchers) && base.is_a?(RSpec::Matchers)
       super
     end
-  })
+  end)
 end
 
 # Rack app for Capybara which returns the latest coverage report from Aruba temp project dir

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,16 +5,21 @@
 
 require "bundler"
 Bundler.setup
-# require order matters, capybara needs to be there before aruba for the RSpec shadowing fix to work (see slightly below)
 require "capybara/cucumber"
 require "capybara/apparition"
 require "aruba/cucumber"
 require "aruba/config/jruby" if RUBY_ENGINE == "jruby"
 require "simplecov"
 
-# Small workaround I found for the RSpec/aruba shadowing problem showcased in https://github.com/PragTob/all_conflict/
-# It _seems_ to work for now but it's definitely not ideal. Wish this was fixed in Capybara.
-Aruba::Api::Core.include(Capybara::RSpecMatcherProxies)
+# Monkey-patching Capybara::DSL if Capybara::DSLRSpecProxyInstaller has no `extended` hook
+unless Module.new.extend(RSpec::Matchers).extend(Capybara::DSL).singleton_class.ancestors.include?(Capybara::RSpecMatcherProxies)
+  Capybara::DSL.extend(Module.new {
+    def extended(base)
+      base.extend(::Capybara::RSpecMatcherProxies) if defined?(::RSpec::Matchers) && base.is_a?(::RSpec::Matchers)
+      super
+    end
+  })
+end
 
 # Rack app for Capybara which returns the latest coverage report from Aruba temp project dir
 coverage_dir = File.expand_path("../../tmp/aruba/project/coverage/", __dir__)

--- a/lib/simplecov/lines_classifier.rb
+++ b/lib/simplecov/lines_classifier.rb
@@ -8,8 +8,8 @@ module SimpleCov
     RELEVANT = 0
     NOT_RELEVANT = nil
 
-    WHITESPACE_LINE = /^\s*$/
-    COMMENT_LINE = /^\s*#/
+    WHITESPACE_LINE = /^\s*$/.freeze
+    COMMENT_LINE = /^\s*#/.freeze
     WHITESPACE_OR_COMMENT_LINE = Regexp.union(WHITESPACE_LINE, COMMENT_LINE)
 
     def self.no_cov_line

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -190,7 +190,7 @@ module SimpleCov
       end
     end
 
-    SHEBANG_REGEX = /\A#!/
+    SHEBANG_REGEX = /\A#!/.freeze
     def shebang?(line)
       SHEBANG_REGEX.match?(line)
     end
@@ -202,7 +202,7 @@ module SimpleCov
       lines.concat([current_line], ensure_remove_undefs(file.readlines))
     end
 
-    RUBY_FILE_ENCODING_MAGIC_COMMENT_REGEX = /\A#\s*(?:-\*-)?\s*(?:en)?coding:\s*(\S+)\s*(?:-\*-)?\s*\z/
+    RUBY_FILE_ENCODING_MAGIC_COMMENT_REGEX = /\A#\s*(?:-\*-)?\s*(?:en)?coding:\s*(\S+)\s*(?:-\*-)?\s*\z/.freeze
     def set_encoding_based_on_magic_comment(file, line)
       # Check for encoding magic comment
       # Encoding magic comment must be placed at first line except for shebang

--- a/simplecov.gemspec
+++ b/simplecov.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
 "rubygems_mfa_required" => "true"
   }
 
-  gem.required_ruby_version = ">= 3.0.0"
+  gem.required_ruby_version = ">= 2.7.0"
 
   gem.add_dependency "docile", "~> 1.1"
   gem.add_dependency "simplecov-html", "~> 0.11"


### PR DESCRIPTION
This PR brings Ruby 2.7 back to the CI matrix by monkey-patching Capybara to correctly switch three `all` methods defined by Capybara, RSpec, and Aruba.

See https://github.com/teamcapybara/capybara/pull/2771 for the details of the Capybara patch.