### PR TITLE
Follow the repo convention to use `floor` instead of `round` to provide actionable coverage metrics

### DIFF
--- a/lib/simplecov/formatter/simple_formatter.rb
+++ b/lib/simplecov/formatter/simple_formatter.rb
@@ -14,7 +14,7 @@ module SimpleCov
           output << ("=" * 40)
           output << "\n"
           files.each do |file|
-            output << "#{file.filename} (coverage: #{file.covered_percent.round(2)}%)\n"
+            output << "#{file.filename} (coverage: #{file.covered_percent.floor(2)}%)\n"
           end
           output << "\n"
         end

--- a/spec/coverage_for_eval_spec.rb
+++ b/spec/coverage_for_eval_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "coverage for eval" do
       let(:command) { "ruby eval_test.rb" }
 
       it "records coverage for erb" do
-        expect(@stdout).to include(" 2 / 3 LOC")
+        expect(@stdout).to include("Line Coverage: 66.67% (2 / 3)")
       end
     end
   end


### PR DESCRIPTION
Use `floor(2)` rather than `round(2)` as we do elsewhere across `Simplcov`

Follow up and relates to:
* https://github.com/simplecov-ruby/simplecov/pull/773/

Relates to and possibly helps with:
* https://github.com/simplecov-ruby/simplecov/issues/1115