### PR TITLE
Add logger to deps and load in early in test Rails app.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :development do
   gem "rake"
   gem "rspec"
   gem "pry"
-  gem "rubocop"
+  gem "rubocop", "~> 1.70.0" if RUBY_VERSION > "3.2"
   gem "test-unit"
   gem "logger"
   # Explicitly add webrick because it has been removed from stdlib in Ruby 3.0

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development do
   gem "pry"
   gem "rubocop"
   gem "test-unit"
+  gem "logger"
   # Explicitly add webrick because it has been removed from stdlib in Ruby 3.0
   gem "webrick"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ DEPENDENCIES
   rackup
   rake
   rspec
-  rubocop
+  rubocop (~> 1.70.0)
   simplecov!
   test-unit
   webrick

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     json (2.9.1)
     json (2.9.1-java)
     language_server-protocol (3.17.0.3)
+    logger (1.7.0)
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)

--- a/test_projects/rails/rspec_rails/Gemfile
+++ b/test_projects/rails/rspec_rails/Gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 # added gems
+gem "logger"
 
 gem "rspec-rails"
 gem "simplecov", path: "../../.."

--- a/test_projects/rails/rspec_rails/config/application.rb
+++ b/test_projects/rails/rspec_rails/config/application.rb
@@ -1,5 +1,6 @@
 require_relative "boot"
 
+require "logger"
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"


### PR DESCRIPTION
- it is not loaded anymore as a side-effect of ruby-concurrent
- fix is included in Rails 7.0, but test app is still Rails 6.1 (https://github.com/rails/rails/pull/54264)
- lock RuboCop on CI, new cops are not compatible yet with current codebase