### PR TITLE
Restore capture_stderr helper used by JSON formatter specs

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -16,3 +16,12 @@ end
 def source_fixture_base_directory
   @source_fixture_base_directory ||= File.dirname(__FILE__)
 end
+
+def capture_stderr
+  previous_stderr = $stderr
+  $stderr = StringIO.new
+  yield
+  $stderr.string
+ensure
+  $stderr = previous_stderr
+end


### PR DESCRIPTION
Restores `capture_stderr` to `spec/helper.rb`. It was dropped in 2729bdf when nothing was using it, but the concurrent-overwrite warning specs added in f9b698a depend on it. The two changes only collided after rebase, so the merged tip of main fails on every Ruby version with `NoMethodError: undefined method 'capture_stderr'` in four examples in `spec/json_formatter_spec.rb`.