### PR TITLE
Fix race when parallel workers copy static assets

### DIFF
--- a/lib/simplecov/formatter/html_formatter.rb
+++ b/lib/simplecov/formatter/html_formatter.rb
@@ -39,8 +39,17 @@ module SimpleCov
     private
 
       def copy_static_assets(dest_dir = output_path)
-        Dir[File.join(public_dir, "*")].each do |path|
-          FileUtils.cp_r(path, dest_dir, remove_destination: true)
+        # Copy via temp file + atomic rename so parallel test workers writing
+        # to the same coverage directory don't race on the unlink step.
+        Dir[File.join(public_dir, "*")].each do |src|
+          dest = File.join(dest_dir, File.basename(src))
+          temp = "#{dest}.#{Process.pid}.#{rand(2**32).to_s(36)}"
+          begin
+            FileUtils.cp(src, temp)
+            File.rename(temp, dest)
+          ensure
+            FileUtils.rm_f(temp)
+          end
         end
       end
 


### PR DESCRIPTION
The `parallel_tests.feature` cucumber scenarios fail intermittently on a clean main with `Errno::ENOENT` from inside `HTMLFormatter#copy_static_assets`. Reproducible locally, ~2 of 5 scenarios fail per run.

When parallel rspec workers exit at roughly the same time, each one runs the formatter against the shared coverage directory. `FileUtils.cp_r(path, dest_dir, remove_destination: true)` performs an unlink-then-copy, and one process ends up unlinking an asset (e.g. `favicon_red.png`) just before another process also tries to unlink it.

Switched to per-file copy via a uniquely-named temp file in the destination directory followed by `File.rename`. Rename is atomic and overwrite-safe on POSIX, so two writers landing on the same path no longer race; whichever finishes last wins, and the file is always coherent. The `public/` directory is flat so we don't lose anything by walking files individually instead of using `cp_r`.