### PR TITLE
Add simplecov:disable / simplecov:enable directive comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ Unreleased
 * Removed `docile` gem dependency. The `SimpleCov.configure` DSL block is now evaluated via `instance_exec` with instance variable proxying.
 * Removed automatic activation of `JSONFormatter` when the `CC_TEST_REPORTER_ID` environment variable is set. The default `HTMLFormatter` now emits `coverage.json` alongside the HTML report (using `JSONFormatter.build_hash` to serialize the same payload `JSONFormatter` writes), so the env-var special case is no longer needed.
 
+## Deprecations
+* `# :nocov:` toggle comments (and the configurable `SimpleCov.nocov_token` / `SimpleCov.skip_token`) are deprecated in favor of the new `# simplecov:disable` / `# simplecov:enable` directives. Each file that still uses `# :nocov:` emits a one-time deprecation warning to stderr at load time pointing at the recommended replacement, and any call to `SimpleCov.nocov_token` or `SimpleCov.skip_token` (getter or setter) likewise warns. The directive will be removed in a future release.
+
 ## Enhancements
+* Added `# simplecov:disable` / `# simplecov:enable` directive comments for selectively skipping `line`, `branch`, and `method` coverage. Block form (own line) opens a region until the matching `# simplecov:enable`; inline form (trailing a code line) skips just that line. Categories may be combined (`# simplecov:disable line, branch`); omitting categories targets all three. Any trailing text is treated as a free-form reason and discarded (e.g. `# simplecov:disable line legacy adapter`). Directive markers inside string literals or heredocs are ignored.
 * JSON formatter: `meta.timestamp` is now emitted with millisecond precision (`iso8601(3)`) so the concurrent-overwrite warning can distinguish writes within the same wall-clock second
 * JSON formatter: added `total` section with aggregate coverage statistics (covered, missed, total, percent, strength) for line, branch, and method coverage. Line stats additionally include `omitted` (count of blank/comment lines, i.e. lines that cannot be covered)
 * JSON formatter: per-file output now includes `total_lines`, `lines_covered_percent`, and when enabled: `branches_covered_percent`, `methods` array, and `methods_covered_percent`

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ Getting started
     # Previous content of test helper now starts here
     ```
 
-    **Note:** If SimpleCov starts after your application code is already loaded
-    (via `require`), it won't be able to track your files and their coverage!
-    The `SimpleCov.start` **must** be issued **before any of your application
-    code is required!**
+    > [!IMPORTANT]
+    > If SimpleCov starts after your application code is already loaded
+    > (via `require`), it won't be able to track your files and their coverage!
+    > The `SimpleCov.start` **must** be issued **before any of your application
+    > code is required!**
 
     This is especially true if you use anything that keeps your test application loaded like Spring; check out the **[Spring section](#want-to-use-spring-with-simplecov)**.
 
@@ -101,8 +102,9 @@ Getting started
    xdg-open coverage/index.html
    ```
 
-   **Note:** [This guide](https://dwheeler.com/essays/open-files-urls.html) can help if you're unsure which command your particular
-   operating system requires.
+   > [!NOTE]
+   > [This guide](https://dwheeler.com/essays/open-files-urls.html) can help if you're unsure which command your particular
+   > operating system requires.
 
 5. Add the following to your `.gitignore` file to ensure that coverage results
    are not tracked by Git (optional):
@@ -462,21 +464,41 @@ You can pass in an array containing any of the other filter types.
 
 #### Ignoring/skipping code
 
-You can exclude code from the coverage report by wrapping it in `# :nocov:`.
+You can disable coverage by category with `# simplecov:disable` and `# simplecov:enable` comments. The available
+categories are `line`, `branch`, and `method`; they may be combined with commas, and omitting them targets all three.
+Anything trailing the directive is treated as a free-form reason and ignored — no separator is required, though `--`
+or any other visual marker is fine if you prefer one.
 
 ```ruby
-# :nocov:
-def skip_this_method
+# simplecov:disable line
+def skipped_lines
   never_reached
 end
-# :nocov:
+# simplecov:enable line
+
+# simplecov:disable branch, method legacy adapter, scheduled for removal
+class LegacyAdapter
+  def call(value)
+    value ? :yes : :no
+  end
+end
+# simplecov:enable
+
+raise "absurd" # simplecov:disable
 ```
 
-The name of the token can be changed to your liking. [Learn more about the nocov feature.]( https://github.com/simplecov-ruby/simplecov/blob/main/features/config_nocov_token.feature)
+Inline directives (trailing real code) only affect the line they sit on. Block directives sit on their own line and
+remain in effect until the matching `# simplecov:enable` for the same category — or end of file if never closed.
+Directive markers inside string literals or heredocs are ignored.
 
-**Note:** You shouldn't have to use the nocov token to skip private methods that are being included in your coverage. If
-you appropriately test the public interface of your classes and objects you should automatically get full coverage of
-your private methods.
+> [!WARNING]
+> The older `# :nocov:` toggle still works but is **deprecated** and will be removed in a future release. Each file
+> that uses it emits a one-time deprecation warning pointing at the recommended `# simplecov:disable` /
+> `# simplecov:enable` replacement. The configurable token name (`SimpleCov.nocov_token`) is similarly deprecated.
+
+> [!NOTE]
+> You shouldn't have to skip private methods that are being included in your coverage. If you appropriately test
+> the public interface of your classes and objects you should automatically get full coverage of your private methods.
 
 ## Default root filter and coverage for things outside of it
 

--- a/features/config_nocov_token.feature
+++ b/features/config_nocov_token.feature
@@ -2,7 +2,12 @@
 Feature:
 
   Code wrapped in # :nocov: will be ignored by coverage reports.
-  The name of the token can be configured with SimpleCov.nocov_token or SimpleCov.skip_token
+  The name of the token can be configured with SimpleCov.nocov_token or SimpleCov.skip_token.
+
+  NOTE: `# :nocov:` and the configurable token are deprecated. Each file that
+  uses the token emits a one-time deprecation warning to stderr at load time
+  pointing at the recommended `# simplecov:disable` / `# simplecov:enable`
+  replacement.
 
   Background:
     Given I'm working on the project "faked_project"

--- a/features/skipping_code_blocks_manually.feature
+++ b/features/skipping_code_blocks_manually.feature
@@ -4,6 +4,11 @@ Feature:
   When code is wrapped in :nocov: comment blocks, it does not count
   against the coverage numbers.
 
+  NOTE: `# :nocov:` is deprecated. Each file that uses it emits a one-time
+  deprecation warning to stderr at load time. New code should prefer
+  `# simplecov:disable` / `# simplecov:enable` (see
+  features/skipping_with_directives.feature).
+
   Background:
     Given I'm working on the project "faked_project"
     Given SimpleCov for Test/Unit is configured with:

--- a/features/skipping_with_directives.feature
+++ b/features/skipping_with_directives.feature
@@ -1,0 +1,103 @@
+@test_unit @nocov
+Feature:
+
+  When code is wrapped in `# simplecov:disable` / `# simplecov:enable`
+  comment blocks (or trailed by an inline `# simplecov:disable`), it does
+  not count against the coverage numbers.
+
+  Background:
+    Given I'm working on the project "faked_project"
+    Given SimpleCov for Test/Unit is configured with:
+      """
+      require 'simplecov'
+      SimpleCov.start 'test_frameworks'
+      """
+
+  Scenario: Block disable of line coverage
+    Given a file named "lib/faked_project/directive.rb" with:
+      """
+      class SourceCodeWithDirective
+        # simplecov:disable line
+        def some_weird_code
+          never_reached
+        rescue => err
+          but no one cares about invalid ruby here
+        end
+        # simplecov:enable line
+      end
+      """
+
+    When I open the coverage report generated with `bundle exec rake test`
+
+    Then I should see the source files:
+      | name                                    | coverage |
+      | lib/faked_project.rb                    | 100.00%  |
+      | lib/faked_project/some_class.rb         | 80.00%   |
+      | lib/faked_project/framework_specific.rb | 75.00%   |
+      | lib/faked_project/meta_magic.rb         | 100.00%  |
+      | lib/faked_project/directive.rb          | 100.00%  |
+
+    And there should be 7 skipped lines in the source files
+
+  Scenario: Inline disable of a single line
+    Given a file named "lib/faked_project/directive.rb" with:
+      """
+      class SourceCodeWithDirective
+        def boom(value)
+          value || raise("absurd") # simplecov:disable
+        end
+      end
+      """
+
+    When I open the coverage report generated with `bundle exec rake test`
+
+    Then I should see the source files:
+      | name                                    | coverage |
+      | lib/faked_project.rb                    | 100.00%  |
+      | lib/faked_project/some_class.rb         | 80.00%   |
+      | lib/faked_project/framework_specific.rb | 75.00%   |
+      | lib/faked_project/meta_magic.rb         | 100.00%  |
+      | lib/faked_project/directive.rb          | 100.00%  |
+
+    And there should be 1 skipped lines in the source files
+
+  Scenario: Block disable with a free-form trailing reason
+    Given a file named "lib/faked_project/directive.rb" with:
+      """
+      class SourceCodeWithDirective
+        # simplecov:disable line legacy adapter, scheduled for removal
+        def some_weird_code
+          never_reached
+        rescue => err
+          but no one cares about invalid ruby here
+        end
+        # simplecov:enable line
+      end
+      """
+
+    When I open the coverage report generated with `bundle exec rake test`
+
+    Then I should see the source files:
+      | name                                    | coverage |
+      | lib/faked_project.rb                    | 100.00%  |
+      | lib/faked_project/some_class.rb         | 80.00%   |
+      | lib/faked_project/framework_specific.rb | 75.00%   |
+      | lib/faked_project/meta_magic.rb         | 100.00%  |
+      | lib/faked_project/directive.rb          | 100.00%  |
+
+    And there should be 7 skipped lines in the source files
+
+  Scenario: Directive markers inside string literals are ignored
+    Given a file named "lib/faked_project/directive.rb" with:
+      """
+      class SourceCodeWithDirective
+        BANNER = "# simplecov:disable"
+        def message
+          BANNER
+        end
+      end
+      """
+
+    When I open the coverage report generated with `bundle exec rake test`
+
+    Then there should be 0 skipped lines in the source files

--- a/lib/simplecov/configuration.rb
+++ b/lib/simplecov/configuration.rb
@@ -136,12 +136,25 @@ module SimpleCov
     #
     # Configure with SimpleCov.nocov_token('skip') or it's alias SimpleCov.skip_token('skip')
     #
+    # DEPRECATED: prefer `# simplecov:disable` / `# simplecov:enable` block comments
+    # (see SimpleCov::Directive). The `# :nocov:` toggle and this configuration hook
+    # will be removed in a future release.
+    #
     def nocov_token(nocov_token = nil)
-      return @nocov_token if defined?(@nocov_token) && nocov_token.nil?
-
-      @nocov_token = nocov_token || "nocov"
+      warn "#{Kernel.caller.first}: [DEPRECATION] `SimpleCov.nocov_token` and `SimpleCov.skip_token` are deprecated. " \
+           "Replace with `# simplecov:disable` / `# simplecov:enable` block comments."
+      current_nocov_token(nocov_token)
     end
     alias skip_token nocov_token
+
+    # Internal accessor used by SimpleCov to recognise `# :nocov:` markers
+    # without emitting the public-API deprecation warning. Will be removed
+    # alongside the deprecated `nocov_token` setter.
+    def current_nocov_token(value = nil)
+      return @nocov_token if defined?(@nocov_token) && value.nil?
+
+      @nocov_token = value || "nocov"
+    end
 
     #
     # Returns the configured groups. Add groups using SimpleCov.add_group

--- a/lib/simplecov/directive.rb
+++ b/lib/simplecov/directive.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "ripper"
+
+module SimpleCov
+  # Parses `# simplecov:disable` / `# simplecov:enable` directive comments.
+  #
+  # Two forms are supported:
+  #
+  # Block form (the directive is the entire comment on its own line) opens a
+  # region that runs until the matching `# simplecov:enable`:
+  #
+  #   # simplecov:disable line
+  #   ...
+  #   # simplecov:enable line
+  #
+  # Inline form (the directive trails real code on the same line) only affects
+  # that single line and does not need to be re-enabled:
+  #
+  #   raise "absurd" # simplecov:disable
+  #
+  # Categories are `:line`, `:branch`, and `:method`. They may be combined
+  # with commas. Omitting categories targets all three.
+  #
+  # Any text after the directive (and the optional category list) is treated
+  # as a free-form reason and discarded:
+  #
+  #   # simplecov:disable line not worth testing this glue
+  #
+  # As a consequence, an unrecognised category name silently falls into the
+  # reason bucket. `# simplecov:disable cyclomatic` is parsed as the bare
+  # form (disable everything) with reason "cyclomatic" — a deliberate
+  # over-disable so the typo is visible in the report rather than silently
+  # disabling nothing.
+  #
+  # Comment extraction goes through `Ripper.lex` so directive markers inside
+  # string literals or heredocs are correctly ignored.
+  class Directive
+    CATEGORIES = %i[line branch method].freeze
+
+    CATEGORY_PATTERN = "(?:#{CATEGORIES.join('|')})"
+    CATEGORIES_PATTERN = "(?:#{CATEGORY_PATTERN}(?:\\s*,\\s*#{CATEGORY_PATTERN})*)"
+    PATTERN = /
+      \#\s*simplecov\s*:\s*
+      (?<mode>disable|enable)\b
+      (?:\s+(?<categories>#{CATEGORIES_PATTERN}))?
+      .*?
+      \s*\z
+    /x.freeze
+
+    attr_reader :line_number, :mode, :categories
+
+    # Walk an array of source lines and return the disabled line ranges per
+    # category as `{ line: [Range, ...], branch: [...], method: [...] }`.
+    # An unclosed `disable` block extends to the end of the file.
+    def self.disabled_ranges(src_lines)
+      lines = src_lines.to_a
+      ranges = CATEGORIES.to_h { |category| [category, []] }
+      open_starts = {}
+
+      directives_in(lines).each { |directive| directive.apply(ranges, open_starts) }
+      open_starts.each { |category, start| ranges[category] << (start..lines.size) }
+
+      ranges
+    end
+
+    # Extract every directive in the file, in source order. Comments inside
+    # string literals or heredocs are skipped because Ripper.lex doesn't tag
+    # them as :on_comment tokens.
+    def self.directives_in(lines)
+      return [] unless source_might_contain_directive?(lines)
+
+      comments_in(lines).filter_map do |line_number, column, text|
+        parse_comment(lines, line_number, column, text)
+      end
+    end
+
+    # Cheap pre-check so we don't tokenize files that obviously can't contain
+    # a directive.
+    def self.source_might_contain_directive?(lines)
+      lines.any? do |line|
+        line.include?("simplecov")
+      rescue ArgumentError, EncodingError
+        false
+      end
+    end
+
+    def self.parse_comment(lines, line_number, column, text)
+      match = PATTERN.match(text)
+      return nil unless match
+
+      new(
+        line_number: line_number,
+        mode:        match[:mode].to_sym,
+        categories:  parse_categories(match[:categories]),
+        inline:      inline?(lines, line_number, column + match.begin(0))
+      )
+    rescue ArgumentError, EncodingError
+      # E.g., comment text contains an invalid byte sequence in UTF-8.
+      nil
+    end
+
+    def self.parse_categories(text)
+      return CATEGORIES.dup if text.nil?
+
+      text.split(/\s*,\s*/).map(&:to_sym)
+    end
+
+    # Whether the directive sits after non-whitespace content on its line.
+    # `column` is the byte column of the directive's `#` in the source line,
+    # adjusted for any prefix that may precede it within the comment token
+    # (e.g., `# prefix # simplecov:disable line`).
+    def self.inline?(lines, line_number, column)
+      line = lines[line_number - 1].to_s
+      !line.byteslice(0, column).to_s.strip.empty?
+    rescue ArgumentError, EncodingError
+      false
+    end
+
+    def self.comments_in(lines)
+      source = lines.map { |line| line.end_with?("\n") ? line : "#{line}\n" }.join
+      Ripper.lex(source).filter_map do |(line_number, column), type, text|
+        [line_number, column, text] if type == :on_comment
+      end
+    rescue ArgumentError, EncodingError
+      []
+    end
+
+    private_class_method :directives_in, :source_might_contain_directive?,
+                         :parse_comment, :parse_categories, :inline?, :comments_in
+
+    def initialize(line_number:, mode:, categories:, inline:)
+      @line_number = line_number
+      @mode        = mode
+      @categories  = categories
+      @inline      = inline
+    end
+
+    def disabled?
+      mode == :disable
+    end
+
+    def enabled?
+      mode == :enable
+    end
+
+    def inline?
+      @inline
+    end
+
+    # Apply this directive's effect to the in-flight per-category state.
+    # Inline directives mark just their line; block disables open a region;
+    # block enables close one. Re-opening an already-open block is a no-op.
+    def apply(ranges, open_starts)
+      categories.each do |category|
+        if inline?
+          ranges[category] << (line_number..line_number) if disabled?
+        elsif disabled?
+          open_starts[category] ||= line_number
+        elsif (start = open_starts.delete(category))
+          ranges[category] << (start..line_number)
+        end
+      end
+    end
+  end
+end

--- a/lib/simplecov/lines_classifier.rb
+++ b/lib/simplecov/lines_classifier.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "set"
+require_relative "directive"
+
 module SimpleCov
   # Classifies whether lines are relevant for code coverage analysis.
   # Comments & whitespace lines, and :nocov: token blocks, are considered not relevant.
@@ -13,7 +16,7 @@ module SimpleCov
     WHITESPACE_OR_COMMENT_LINE = Regexp.union(WHITESPACE_LINE, COMMENT_LINE)
 
     def self.no_cov_line
-      /^(\s*)#(\s*)(:#{SimpleCov.nocov_token}:)/o
+      /^(\s*)#(\s*)(:#{SimpleCov.current_nocov_token}:)/o
     end
 
     def self.no_cov_line?(line)
@@ -31,17 +34,28 @@ module SimpleCov
     end
 
     def classify(lines)
+      lines = lines.to_a
+      directive_disabled = directive_disabled_line_set(lines)
       skipping = false
 
-      lines.map do |line|
-        if self.class.no_cov_line?(line)
-          skipping = !skipping
-          NOT_RELEVANT
-        elsif skipping || self.class.whitespace_line?(line)
-          NOT_RELEVANT
-        else
-          RELEVANT
-        end
+      lines.map.with_index(1) do |line, line_number|
+        skipping = !skipping if self.class.no_cov_line?(line)
+        not_relevant_line?(line, line_number, skipping, directive_disabled) ? NOT_RELEVANT : RELEVANT
+      end
+    end
+
+  private
+
+    def not_relevant_line?(line, line_number, skipping, directive_disabled)
+      skipping ||
+        self.class.no_cov_line?(line) ||
+        directive_disabled.include?(line_number) ||
+        self.class.whitespace_line?(line)
+    end
+
+    def directive_disabled_line_set(lines)
+      Directive.disabled_ranges(lines).fetch(:line).each_with_object(Set.new) do |range, set|
+        range.each { |line_number| set.add(line_number) }
       end
     end
   end

--- a/lib/simplecov/source_file.rb
+++ b/lib/simplecov/source_file.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
+require "set"
 require "strscan"
+require_relative "directive"
 
 module SimpleCov
   #
@@ -195,6 +197,8 @@ module SimpleCov
     def build_no_cov_chunks
       no_cov_lines = src.map.with_index(1).select { |line_src, _index| LinesClassifier.no_cov_line?(line_src) }
 
+      warn_no_cov_deprecation(no_cov_lines.first.last) if no_cov_lines.any?
+
       # if we have an uneven number of nocovs we assume they go to the
       # end of the file, the source doesn't really matter
       # Can't deal with this within the each_slice due to differing
@@ -204,6 +208,27 @@ module SimpleCov
       no_cov_lines.each_slice(2).map do |(_line_src_start, index_start), (_line_src_end, index_end)|
         index_start..index_end
       end
+    end
+
+    @nocov_warned = Set.new
+
+    class << self
+      attr_reader :nocov_warned
+    end
+
+    # Emit a one-time-per-file deprecation warning pointing the user at the
+    # `# simplecov:disable` / `# simplecov:enable` replacement.
+    def warn_no_cov_deprecation(first_line_number)
+      return unless self.class.nocov_warned.add?(filename)
+
+      token = SimpleCov.current_nocov_token
+      warn "#{filename}:#{first_line_number}: [DEPRECATION] `# :#{token}:` is deprecated and will be removed " \
+           "in a future release. Replace with `# simplecov:disable` / `# simplecov:enable` block comments."
+    end
+
+    # Per-category disabled line ranges from `# simplecov:disable` directives.
+    def directive_chunks
+      @directive_chunks ||= Directive.disabled_ranges(src)
     end
 
     def load_source
@@ -263,6 +288,7 @@ module SimpleCov
       # chunks are 1-based and are expected to be like this in other parts (and it's also
       # arguably more understandable)
       no_cov_chunks.each { |chunk| lines[(chunk.begin - 1)..(chunk.end - 1)].each(&:skipped!) }
+      directive_chunks.fetch(:line).each { |chunk| lines[(chunk.begin - 1)..(chunk.end - 1)].each(&:skipped!) }
 
       lines
     end
@@ -299,10 +325,16 @@ module SimpleCov
     end
 
     def process_skipped_branches(branches)
-      return branches if no_cov_chunks.empty?
+      chunks = no_cov_chunks + directive_chunks.fetch(:branch)
+      return branches if chunks.empty?
 
+      # A non-inline branch's source range starts on its arm body (e.g. the
+      # `:yes` line of `if cond / :yes / else / :no / end`), but `report_line`
+      # is the condition line above it — that's where the user sees the
+      # branch in the report and where they would naturally place an inline
+      # `# simplecov:disable branch` directive. Honour both.
       branches.each do |branch|
-        branch.skipped! if no_cov_chunks.any? { |no_cov_chunk| branch.overlaps_with?(no_cov_chunk) }
+        branch.skipped! if chunks.any? { |chunk| branch.overlaps_with?(chunk) || chunk.include?(branch.report_line) }
       end
 
       branches
@@ -416,10 +448,23 @@ module SimpleCov
     end
 
     def build_methods
-      coverage_data.fetch("methods", {}).map do |info, hit_count|
+      methods = coverage_data.fetch("methods", {}).map do |info, hit_count|
         info = restore_ruby_data_structure(info)
         SourceFile::Method.new(self, info, hit_count)
       end
+
+      process_skipped_methods(methods)
+    end
+
+    def process_skipped_methods(methods)
+      method_chunks = directive_chunks.fetch(:method)
+      return methods if method_chunks.empty?
+
+      methods.each do |method|
+        method.skipped! if method_chunks.any? { |chunk| method.overlaps_with?(chunk) }
+      end
+
+      methods
     end
 
     def method_coverage_statistics

--- a/lib/simplecov/source_file/method.rb
+++ b/lib/simplecov/source_file/method.rb
@@ -24,12 +24,24 @@ module SimpleCov
         @skipped = lines.all?(&:skipped?)
       end
 
+      # Flag the method as skipped directly, without going through its lines.
+      def skipped!
+        @skipped = true
+      end
+
       def missed?
         !skipped? && coverage.zero?
       end
 
       def lines
         @lines ||= start_line && end_line ? source_file.lines[(start_line - 1)..(end_line - 1)] : []
+      end
+
+      # Whether this method's source range intersects the given inclusive line range.
+      def overlaps_with?(line_range)
+        return false unless start_line && end_line
+
+        start_line <= line_range.end && end_line >= line_range.begin
       end
 
       def to_s

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -24,6 +24,53 @@ describe SimpleCov::Configuration do
     end
   end
 
+  describe "#nocov_token" do
+    it "warns of deprecation when called as a getter" do
+      stderr = capture_stderr { config.nocov_token }
+
+      expect(stderr).to include("[DEPRECATION]")
+      expect(stderr).to include("`SimpleCov.nocov_token`")
+      expect(stderr).to include("`# simplecov:disable`")
+      expect(stderr).to include("`# simplecov:enable`")
+    end
+
+    it "warns of deprecation when called as a setter" do
+      stderr = capture_stderr { config.nocov_token("skippit") }
+
+      expect(stderr).to include("[DEPRECATION]")
+    end
+
+    it "still returns the configured token (after the deprecation warning)" do
+      capture_stderr { config.nocov_token("skippit") }
+      stderr = capture_stderr { @value = config.nocov_token }
+
+      expect(@value).to eq "skippit"
+      expect(stderr).to include("[DEPRECATION]") # the read still warns
+    end
+
+    it "is aliased as #skip_token, which also warns" do
+      stderr = capture_stderr { config.skip_token("skippit") }
+
+      expect(stderr).to include("[DEPRECATION]")
+      expect(config.current_nocov_token).to eq "skippit"
+    end
+  end
+
+  describe "#current_nocov_token" do
+    it "returns the configured token without emitting a deprecation warning" do
+      stderr = capture_stderr { @value = config.current_nocov_token }
+
+      expect(@value).to eq "nocov"
+      expect(stderr).to be_empty
+    end
+
+    it "honours a value previously set via #nocov_token" do
+      capture_stderr { config.nocov_token("skippit") }
+
+      expect(config.current_nocov_token).to eq "skippit"
+    end
+  end
+
   describe "#tracked_files" do
     context "when configured" do
       let(:glob) { "{app,lib}/**/*.rb" }

--- a/spec/directive_spec.rb
+++ b/spec/directive_spec.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+require "helper"
+
+describe SimpleCov::Directive do
+  describe ".disabled_ranges" do
+    let(:empty_ranges) { {line: [], branch: [], method: []} }
+
+    it "returns empty ranges per category for source without directives" do
+      expect(described_class.disabled_ranges(["def foo", "  bar", "end"])).to eq empty_ranges
+    end
+
+    it "treats a bare disable/enable as targeting all categories" do
+      ranges = described_class.disabled_ranges([
+                                                 "# simplecov:disable", # 1
+                                                 "code",                # 2
+                                                 "# simplecov:enable"   # 3
+                                               ])
+
+      expect(ranges[:line]).to eq [1..3]
+      expect(ranges[:branch]).to eq [1..3]
+      expect(ranges[:method]).to eq [1..3]
+    end
+
+    it "builds ranges between matching block disable/enable for the named category" do
+      ranges = described_class.disabled_ranges([
+                                                 "def foo", # 1
+                                                 "  # simplecov:disable line", # 2
+                                                 "  bar",                      # 3
+                                                 "  baz",                      # 4
+                                                 "  # simplecov:enable line",  # 5
+                                                 "end"                         # 6
+                                               ])
+
+      expect(ranges).to eq(line: [2..5], branch: [], method: [])
+    end
+
+    it "extends an unclosed disable to the end of file" do
+      ranges = described_class.disabled_ranges([
+                                                 "x = 1", # 1
+                                                 "# simplecov:disable", # 2
+                                                 "y = 2",               # 3
+                                                 "z = 3"                # 4
+                                               ])
+
+      expect(ranges).to eq(line: [2..4], branch: [2..4], method: [2..4])
+    end
+
+    it "treats inline disable as a single-line range" do
+      ranges = described_class.disabled_ranges([
+                                                 "x = 1", # 1
+                                                 'raise "absurd" # simplecov:disable', # 2
+                                                 "y = 2"                               # 3
+                                               ])
+
+      expect(ranges).to eq(line: [2..2], branch: [2..2], method: [2..2])
+    end
+
+    it "tracks each category independently" do
+      ranges = described_class.disabled_ranges([
+                                                 "# simplecov:disable line", # 1
+                                                 "# simplecov:disable branch,method", # 2
+                                                 "code",                             # 3
+                                                 "# simplecov:enable line",          # 4
+                                                 "code",                             # 5
+                                                 "# simplecov:enable branch"         # 6
+                                               ])
+
+      expect(ranges[:line]).to eq [1..4]
+      expect(ranges[:branch]).to eq [2..6]
+      expect(ranges[:method]).to eq [2..6]
+    end
+
+    it "ignores enable without a matching disable" do
+      ranges = described_class.disabled_ranges([
+                                                 "code", # 1
+                                                 "# simplecov:enable line", # 2
+                                                 "more code"                # 3
+                                               ])
+
+      expect(ranges[:line]).to eq []
+    end
+
+    it "supports multiple disable/enable pairs in the same file" do
+      ranges = described_class.disabled_ranges([
+                                                 "# simplecov:disable line", # 1
+                                                 "a",                        # 2
+                                                 "# simplecov:enable line",  # 3
+                                                 "b",                        # 4
+                                                 "# simplecov:disable line", # 5
+                                                 "c",                        # 6
+                                                 "# simplecov:enable line"   # 7
+                                               ])
+
+      expect(ranges[:line]).to eq [1..3, 5..7]
+    end
+
+    it "tolerates whitespace around the marker, colon, and category separators" do
+      ranges = described_class.disabled_ranges([
+                                                 "#simplecov:disable line", # 1
+                                                 "code",                                      # 2
+                                                 "  #  simplecov : enable line",              # 3
+                                                 "code",                                      # 4
+                                                 "# simplecov:disable method ,  branch",      # 5
+                                                 "code",                                      # 6
+                                                 "# simplecov:enable method, branch"          # 7
+                                               ])
+
+      expect(ranges[:line]).to eq [1..3]
+      expect(ranges[:branch]).to eq [5..7]
+      expect(ranges[:method]).to eq [5..7]
+    end
+
+    describe "free-form trailing reason" do
+      it "accepts an unstructured reason after a block disable" do
+        ranges = described_class.disabled_ranges([
+                                                   "# simplecov:disable line legacy adapter, scheduled for removal", # 1
+                                                   "code",                                                           # 2
+                                                   "# simplecov:enable line"                                         # 3
+                                                 ])
+
+        expect(ranges[:line]).to eq [1..3]
+      end
+
+      it "accepts a `--`-prefixed reason for users who like the visual separator" do
+        ranges = described_class.disabled_ranges([
+                                                   "# simplecov:disable line -- legacy adapter, scheduled for removal", # 1
+                                                   "code",                                                              # 2
+                                                   "# simplecov:enable line"                                            # 3
+                                                 ])
+
+        expect(ranges[:line]).to eq [1..3]
+      end
+
+      it "accepts a reason on a bare directive" do
+        ranges = described_class.disabled_ranges([
+                                                   "# simplecov:disable not interesting", # 1
+                                                   "code" # 2
+                                                 ])
+
+        expect(ranges[:line]).to eq [1..2]
+      end
+
+      it "accepts a reason on an inline directive" do
+        ranges = described_class.disabled_ranges([
+                                                   'raise "absurd" # simplecov:disable line impossible', # 1
+                                                   "ok" # 2
+                                                 ])
+
+        expect(ranges[:line]).to eq [1..1]
+      end
+    end
+
+    describe "lenient handling of unrecognised category text" do
+      it "treats an unknown single token as a reason on the bare form (over-disables)" do
+        # The user almost certainly typo-ed a category name. We over-disable
+        # rather than silently no-op so the mistake shows up in the report.
+        ranges = described_class.disabled_ranges([
+                                                   "# simplecov:disable cyclomatic", # 1
+                                                   "code"                            # 2
+                                                 ])
+
+        expect(ranges).to eq(line: [1..2], branch: [1..2], method: [1..2])
+      end
+
+      it "stops parsing categories at the first unrecognised entry, treats the rest as reason" do
+        ranges = described_class.disabled_ranges([
+                                                   "# simplecov:disable line, frobnicate", # 1
+                                                   "code"                                  # 2
+                                                 ])
+
+        expect(ranges[:line]).to eq [1..2]
+        expect(ranges[:branch]).to eq []
+        expect(ranges[:method]).to eq []
+      end
+
+      it "accepts `all` as syntactic sugar for the bare form" do
+        # `all` isn't a real category, so it lands in the reason bucket and the
+        # bare form takes effect — which is what the user wrote anyway.
+        ranges = described_class.disabled_ranges([
+                                                   "# simplecov:disable all", # 1
+                                                   "code"                     # 2
+                                                 ])
+
+        expect(ranges).to eq(line: [1..2], branch: [1..2], method: [1..2])
+      end
+
+      it "discards trailing punctuation as reason text" do
+        ranges = described_class.disabled_ranges([
+                                                   "# simplecov:disable line; please", # 1
+                                                   "code"                              # 2
+                                                 ])
+
+        expect(ranges[:line]).to eq [1..2]
+      end
+
+      it "tolerates a trailing comma in the category list" do
+        ranges = described_class.disabled_ranges([
+                                                   "# simplecov:disable line,", # 1
+                                                   "code"                       # 2
+                                                 ])
+
+        expect(ranges[:line]).to eq [1..2]
+      end
+    end
+
+    describe "still-rejected inputs" do
+      it "ignores an unknown mode" do
+        ranges = described_class.disabled_ranges([
+                                                   "# simplecov:silence line", # 1
+                                                   "code"                      # 2
+                                                 ])
+
+        expect(ranges).to eq(line: [], branch: [], method: [])
+      end
+
+      it "ignores lines containing invalid byte sequences" do
+        bad = +"# simplecov:disable line"
+        bad << 0xC3.chr.force_encoding("UTF-8") # incomplete UTF-8 sequence
+
+        expect(described_class.disabled_ranges([bad, "code"])).to eq empty_ranges
+      end
+    end
+
+    describe "string- and heredoc-safety" do
+      it "ignores a directive marker that appears inside a double-quoted string" do
+        ranges = described_class.disabled_ranges([
+                                                   'BANNER = "# simplecov:disable line"', # 1
+                                                   "puts BANNER" # 2
+                                                 ])
+
+        expect(ranges).to eq empty_ranges
+      end
+
+      it "ignores a directive marker that appears inside a single-quoted string" do
+        ranges = described_class.disabled_ranges([
+                                                   "BANNER = '# simplecov:disable line'", # 1
+                                                   "puts BANNER" # 2
+                                                 ])
+
+        expect(ranges).to eq empty_ranges
+      end
+
+      it "ignores a directive marker that appears inside a heredoc" do
+        ranges = described_class.disabled_ranges([
+                                                   "msg = <<~TEXT", # 1
+                                                   "  # simplecov:disable line", # 2
+                                                   "  body",                     # 3
+                                                   "  # simplecov:enable line",  # 4
+                                                   "TEXT",                       # 5
+                                                   "puts msg"                    # 6
+                                                 ])
+
+        expect(ranges).to eq empty_ranges
+      end
+
+      it "ignores a directive marker inside an interpolated string" do
+        ranges = described_class.disabled_ranges([
+                                                   'name = "x"', # 1
+                                                   'puts "name=#{name} # simplecov:disable line"', # rubocop:disable Lint/InterpolationCheck
+                                                   "ok" # 3
+                                                 ])
+
+        expect(ranges).to eq empty_ranges
+      end
+
+      it "still recognises a real directive on the same file as a string-shaped marker" do
+        ranges = described_class.disabled_ranges([
+                                                   'BANNER = "# simplecov:disable"', # 1
+                                                   "# simplecov:disable line",        # 2
+                                                   "skipped",                         # 3
+                                                   "# simplecov:enable line"          # 4
+                                                 ])
+
+        expect(ranges[:line]).to eq [2..4]
+      end
+    end
+
+    describe "inline detection edge cases" do
+      it "treats indented own-line directives as block, not inline" do
+        ranges = described_class.disabled_ranges([
+                                                   "    # simplecov:disable line", # 1
+                                                   "    code",                     # 2
+                                                   "    # simplecov:enable line"   # 3
+                                                 ])
+
+        expect(ranges[:line]).to eq [1..3]
+      end
+
+      it "treats a directive that follows another `#` segment as inline" do
+        # The whole line is one comment token, but the directive sits after
+        # `# prefix`, so it should only mark its own line.
+        ranges = described_class.disabled_ranges([
+                                                   "# prefix # simplecov:disable line", # 1
+                                                   "still relevant" # 2
+                                                 ])
+
+        expect(ranges[:line]).to eq [1..1]
+      end
+    end
+  end
+end

--- a/spec/json_formatter_spec.rb
+++ b/spec/json_formatter_spec.rb
@@ -340,6 +340,16 @@ describe SimpleCov::Formatter::JSONFormatter do
       end
     end
 
+    # The `json/sample.rb` fixture used in `let(:result)` exercises the
+    # deprecated `# :nocov:` toggle, which writes a one-time deprecation line
+    # to stderr the first time the SourceFile is built. Strip it here so the
+    # "did the formatter itself emit a warning?" assertions stay focused.
+    NOCOV_DEPRECATION_MARKER = "Replace with `# simplecov:disable` / `# simplecov:enable`"
+
+    def reject_nocov_deprecation(stderr)
+      stderr.lines.reject { |line| line.include?(NOCOV_DEPRECATION_MARKER) }.join
+    end
+
     context "when an existing coverage.json predates this process" do
       before do
         FileUtils.mkdir_p("tmp/coverage")
@@ -350,7 +360,7 @@ describe SimpleCov::Formatter::JSONFormatter do
       it "does not warn" do
         stderr = capture_stderr { subject.format(result) }
 
-        expect(stderr).to be_empty
+        expect(reject_nocov_deprecation(stderr)).to be_empty
       end
     end
 
@@ -363,7 +373,7 @@ describe SimpleCov::Formatter::JSONFormatter do
       it "does not warn or raise" do
         stderr = capture_stderr { subject.format(result) }
 
-        expect(stderr).to be_empty
+        expect(reject_nocov_deprecation(stderr)).to be_empty
       end
     end
   end

--- a/spec/lines_classifier_spec.rb
+++ b/spec/lines_classifier_spec.rb
@@ -97,6 +97,57 @@ describe SimpleCov::LinesClassifier do
           expect(classified_lines[5..7]).to all be_irrelevant
         end
       end
+
+      describe "# simplecov:disable line / enable line directives" do
+        it "marks lines inside a paired disable/enable block as not-relevant" do
+          classified_lines = subject.classify [
+            "puts 'before'",
+            "# simplecov:disable line",
+            "puts 'inside 1'",
+            "puts 'inside 2'",
+            "# simplecov:enable line",
+            "puts 'after'"
+          ]
+
+          expect(classified_lines[0]).to be_relevant
+          expect(classified_lines[1..4]).to all be_irrelevant
+          expect(classified_lines[5]).to be_relevant
+        end
+
+        it "treats an unclosed disable as running through end of file" do
+          classified_lines = subject.classify [
+            "puts 'before'",
+            "# simplecov:disable",
+            "puts 'after 1'",
+            "puts 'after 2'"
+          ]
+
+          expect(classified_lines[0]).to be_relevant
+          expect(classified_lines[1..3]).to all be_irrelevant
+        end
+
+        it "applies inline disable to only the trailing line" do
+          classified_lines = subject.classify [
+            "puts 'kept'",
+            "raise 'absurd' # simplecov:disable",
+            "puts 'kept too'"
+          ]
+
+          expect(classified_lines[0]).to be_relevant
+          expect(classified_lines[1]).to be_irrelevant
+          expect(classified_lines[2]).to be_relevant
+        end
+
+        it "does not affect line classification when only branch is disabled" do
+          classified_lines = subject.classify [
+            "# simplecov:disable branch",
+            "puts 'still relevant'",
+            "# simplecov:enable branch"
+          ]
+
+          expect(classified_lines[1]).to be_relevant
+        end
+      end
     end
   end
 

--- a/spec/source_file/method_spec.rb
+++ b/spec/source_file/method_spec.rb
@@ -59,4 +59,35 @@ describe SimpleCov::SourceFile::Method do
       expect(subject.missed?).to eq(true)
     end
   end
+
+  describe "#skipped!" do
+    it "marks the method as skipped regardless of its line coverage" do
+      subject.skipped!
+
+      expect(subject.skipped?).to be true
+      expect(subject.covered?).to be false
+      expect(subject.missed?).to be false
+    end
+  end
+
+  describe "#overlaps_with?" do
+    it "is true when the method's range intersects the given range" do
+      expect(subject.overlaps_with?(3..4)).to be true
+      expect(subject.overlaps_with?(1..2)).to be true
+      expect(subject.overlaps_with?(5..7)).to be true
+    end
+
+    it "is false when the method's range sits entirely outside the given range" do
+      expect(subject.overlaps_with?(6..10)).to be false
+      expect(subject.overlaps_with?(0..1)).to be false
+    end
+
+    context "with nil line info" do
+      let(:info) { ["A", :method1, nil, nil, nil, nil] }
+
+      it "is false" do
+        expect(subject.overlaps_with?(1..10)).to be false
+      end
+    end
+  end
 end

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -365,8 +365,12 @@ describe SimpleCov::SourceFile do
       expect(subject.lines.count).to eq(16)
     end
 
-    it "does not output to stderr" do
-      expect { subject.lines }.not_to output.to_stderr
+    it "does not output to stderr (apart from the :nocov: deprecation)" do
+      SimpleCov::SourceFile.nocov_warned.clear
+      output = capture_stderr { subject.lines }
+      noise = output.lines.reject { |line| line.include?("[DEPRECATION]") }
+
+      expect(noise).to be_empty
     end
   end
 
@@ -795,6 +799,32 @@ describe SimpleCov::SourceFile do
     end
   end
 
+  context "a file using the deprecated # :nocov: directive" do
+    subject do
+      SimpleCov::SourceFile.new(source_fixture("single_nocov.rb"), COVERAGE_FOR_SINGLE_NOCOV_RB)
+    end
+
+    before { SimpleCov::SourceFile.nocov_warned.clear }
+
+    it "warns once per file with the recommended replacement" do
+      stderr = capture_stderr { subject.lines }
+
+      expect(stderr).to include("[DEPRECATION]")
+      expect(stderr).to include("# :nocov:")
+      expect(stderr).to include("# simplecov:disable")
+      expect(stderr).to include("# simplecov:enable")
+      expect(stderr).to include(source_fixture("single_nocov.rb"))
+    end
+
+    it "deduplicates the warning for the same file across SourceFile instances" do
+      capture_stderr { subject.lines }
+      another = SimpleCov::SourceFile.new(source_fixture("single_nocov.rb"), COVERAGE_FOR_SINGLE_NOCOV_RB)
+      stderr = capture_stderr { another.lines }
+
+      expect(stderr).to be_empty
+    end
+  end
+
   context "a file entirely ignored with a single # :nocov:" do
     COVERAGE_FOR_SINGLE_NOCOV_RB = {
       "lines" => [nil, 1, 1, 1, 0, 1, 0, 1, 1, nil, 0, nil, nil, nil],
@@ -980,6 +1010,232 @@ describe SimpleCov::SourceFile do
 
       it "reports 0% method coverage instead of 100%" do
         expect(subject.coverage_statistics[:method].percent).to eq 0.0
+      end
+    end
+  end
+
+  context "with simplecov:disable / enable directives" do
+    def build(coverage_data, source_lines)
+      file = SimpleCov::SourceFile.new("dummy.rb", coverage_data)
+      file.instance_variable_set(:@src, source_lines)
+      file
+    end
+
+    describe "block disable of line coverage" do
+      subject do
+        build(
+          {"lines" => [1, nil, 5, 5, nil, 1], "branches" => {}, "methods" => {}},
+          [
+            "x = 1\n",                       # 1
+            "# simplecov:disable line\n",    # 2
+            "y = 2\n",                       # 3
+            "z = 3\n",                       # 4
+            "# simplecov:enable line\n",     # 5
+            "w = 4\n"                        # 6
+          ]
+        )
+      end
+
+      it "skips lines covered by the directive instead of counting them" do
+        expect(subject.skipped_lines.map(&:line_number)).to eq [2, 3, 4, 5]
+        expect(subject.covered_lines.map(&:line_number)).to eq [1, 6]
+        expect(subject.missed_lines).to eq []
+      end
+    end
+
+    describe "inline disable of line coverage" do
+      subject do
+        build(
+          {"lines" => [1, 0, 1], "branches" => {}, "methods" => {}},
+          [
+            "x = 1\n",
+            "raise \"absurd\" # simplecov:disable\n",
+            "z = 3\n"
+          ]
+        )
+      end
+
+      it "skips only the trailing line" do
+        expect(subject.skipped_lines.map(&:line_number)).to eq [2]
+        expect(subject.covered_lines.map(&:line_number)).to eq [1, 3]
+        expect(subject.missed_lines).to eq []
+      end
+    end
+
+    describe "block disable of method coverage" do
+      subject do
+        build(
+          {
+            "lines"    => [1, nil, 1, nil, nil, 1, nil, nil],
+            "branches" => {},
+            "methods"  => {
+              ["Demo", :covered, 1, 0, 3, 3] => 1,
+              ["Demo", :method_skipped, 6, 0, 8, 3] => 0
+            }
+          },
+          [
+            "def covered\n",                # 1
+            "  1\n",                        # 2
+            "end\n",                        # 3
+            "\n",                           # 4
+            "# simplecov:disable method\n", # 5
+            "def method_skipped\n",         # 6
+            "  1\n",                        # 7
+            "end\n"                         # 8
+          ]
+        )
+      end
+
+      it "marks methods overlapping the region as skipped" do
+        skipped = subject.methods.select(&:skipped?)
+        expect(skipped.map(&:method_name)).to eq [:method_skipped]
+      end
+
+      it "removes skipped methods from covered and missed totals" do
+        expect(subject.covered_methods.map(&:method_name)).to eq [:covered]
+        expect(subject.missed_methods).to eq []
+      end
+
+      it "leaves the lines themselves alone when only method is disabled" do
+        # The method's body lines (6..8) should not be marked skipped solely
+        # because of `simplecov:disable method`.
+        expect(subject.skipped_lines.map(&:line_number)).to eq []
+      end
+    end
+
+    describe "block disable of branch coverage" do
+      subject do
+        build(
+          {
+            "lines"    => [nil, 1, 1, nil, 1, nil, nil],
+            "branches" => {
+              [:if, 0, 2, 0, 6, 3] => {
+                [:then, 1, 3, 2, 3, 7] => 1,
+                [:else, 2, 5, 2, 5, 7] => 0
+              }
+            },
+            "methods" => {}
+          },
+          [
+            "# simplecov:disable branch\n", # 1
+            "if cond\n",                    # 2
+            "  :yes\n",                     # 3
+            "else\n",                       # 4
+            "  :no\n",                      # 5
+            "end\n",                        # 6
+            "# simplecov:enable branch\n"   # 7
+          ]
+        )
+      end
+
+      it "marks the branches inside the region as skipped" do
+        expect(subject.total_branches).to eq []
+        expect(subject.covered_branches).to eq []
+        expect(subject.missed_branches).to eq []
+      end
+    end
+
+    describe "branch coverage with an inline directive on the condition line" do
+      # The directive sits on the `if` line itself. The :then arm's source
+      # range starts on the next line (`:yes`), so a pure overlap check would
+      # miss it. The arm's `report_line` is the condition line, which is
+      # where the user typed the directive — process_skipped_branches honours
+      # report_line membership in addition to range overlap.
+      subject do
+        build(
+          {
+            "lines"    => [1, 1, nil, 1, nil],
+            "branches" => {
+              [:if, 0, 1, 0, 5, 3] => {
+                [:then, 1, 2, 2, 2, 7] => 1,
+                [:else, 2, 4, 2, 4, 7] => 0
+              }
+            },
+            "methods" => {}
+          },
+          [
+            "if cond # simplecov:disable branch\n", # 1
+            "  :yes\n",                              # 2
+            "else\n",                                # 3
+            "  :no\n",                               # 4
+            "end\n"                                  # 5
+          ]
+        )
+      end
+
+      it "skips the :then arm whose report_line falls on the directive" do
+        skipped = subject.branches.select(&:skipped?)
+        expect(skipped.map(&:type)).to include(:then)
+      end
+    end
+
+    describe "branch coverage with a directive inside the branch body" do
+      # A `# simplecov:disable branch` placed inside a single arm of an `if`
+      # should still mark the enclosing branch as skipped, because the branch's
+      # source range (start..end) overlaps the disabled range.
+      subject do
+        build(
+          {
+            "lines"    => [1, 1, nil, 1, 1, nil, 1],
+            "branches" => {
+              [:if, 0, 1, 0, 6, 3] => {
+                [:then, 1, 2, 2, 3, 7] => 1,
+                [:else, 2, 4, 2, 5, 7] => 0
+              }
+            },
+            "methods" => {}
+          },
+          [
+            "if cond\n", # 1
+            "  # simplecov:disable branch\n", # 2
+            "  :yes\n",                     # 3
+            "else\n",                       # 4
+            "  :no\n",                      # 5
+            "end\n",                        # 6
+            "# simplecov:enable branch\n"   # 7
+          ]
+        )
+      end
+
+      it "skips any branch whose range overlaps the disabled region" do
+        expect(subject.branches.select(&:skipped?).size).to eq 2
+        expect(subject.total_branches).to eq []
+      end
+
+      it "leaves line classification untouched when only branch is disabled" do
+        expect(subject.skipped_lines).to eq []
+      end
+    end
+
+    describe "method coverage with a directive inside the method body" do
+      # The directive at line 4 sits inside a method spanning lines 3..6.
+      # `Method#overlaps_with?` should detect the intersection and skip the
+      # method even though the directive isn't on the method's start line.
+      subject do
+        build(
+          {
+            "lines" => [1, nil, 1, nil, nil, nil, nil],
+            "branches" => {},
+            "methods" => {
+              ["Demo", :inner_directive, 3, 0, 6, 3] => 0
+            }
+          },
+          [
+            "x = 1\n", # 1
+            "\n",                             # 2
+            "def inner_directive\n",          # 3
+            "  # simplecov:disable method\n", # 4
+            "  raise 'absurd'\n",             # 5
+            "end\n",                          # 6
+            "# simplecov:enable method\n"     # 7
+          ]
+        )
+      end
+
+      it "skips the method even though the directive is mid-body" do
+        expect(subject.methods.map(&:skipped?)).to eq [true]
+        expect(subject.covered_methods).to eq []
+        expect(subject.missed_methods).to eq []
       end
     end
   end

--- a/spec/support/fail_rspec_on_ruby_warning.rb
+++ b/spec/support/fail_rspec_on_ruby_warning.rb
@@ -36,8 +36,12 @@ private
     lines
   end
 
+  # The :nocov: deprecation warning is fired by fixtures that legitimately
+  # exercise the deprecated toggle. Filter only that exact warning so any
+  # future app-side deprecation still fails the build.
   def split_lines(lines)
-    lines.partition { |line| line.include?(@app_root) }
+    nocov_deprecation_marker = "Replace with `# simplecov:disable` / `# simplecov:enable`"
+    lines.partition { |line| line.include?(@app_root) && !line.include?(nocov_deprecation_marker) }
   end
 
   def print_own_warnings(app_warnings)


### PR DESCRIPTION
Alternative to https://github.com/simplecov-ruby/simplecov/pull/1068 implementing the directive shape proposed at https://github.com/simplecov-ruby/simplecov/pull/1068#issuecomment-4373928363:

```ruby
# simplecov:disable line
# simplecov:disable method, branch
# simplecov:disable                                        <- shorthand for all three categories
# simplecov:disable line legacy adapter, scheduled to die  <- trailing text is a free-form reason
# simplecov:enable
raise "absurd" # simplecov:disable                         <- inline, single line, no enable needed
```

Categories are tracked independently. `# simplecov:disable line` skips those lines from line coverage but still reports any branches and methods that overlap them. `# simplecov:disable method` flags the method directly without depending on its lines being skipped, which is why `Method` gains a `skipped!` setter and an `overlaps_with?` helper alongside the existing inferred-from-lines `skipped?`.

Anything trailing the directive is treated as a free-form reason and discarded. The trade-off is that an unrecognised category name silently falls into the reason bucket and the bare form takes effect, so `# simplecov:disable cyclomatic` ends up over-disabling instead of being rejected. That's a deliberate fail-mode: over-disabling shows up loud in the report (a whole file with no covered lines), whereas silently disabling nothing wouldn't, so typos are easier to catch.

Comment extraction goes through `Ripper.lex`. That keeps the parser honest about Ruby syntax: a directive marker sitting inside a double-quoted string, a single-quoted string, an interpolated string, or a heredoc body is not a directive, and we no longer pretend otherwise. The `# prefix # simplecov:disable line` case (whole line is one comment, but the directive isn't at the start of it) is treated as inline, since the directive's column doesn't sit at the start of the comment text.

The new directives subsume what `# :nocov:` did, so it's deprecated (as is the the configurable `SimpleCov.nocov_token`). The toggle continues to work but each file that uses it now emits a one-time deprecation warning to stderr at load time pointing the user at the `# simplecov:disable` / `# simplecov:enable` replacement. The plan is to remove `:nocov:` entirely in a future release.

The shape of the implementation:

- `SimpleCov::Directive` exposes `Directive.disabled_ranges(src_lines)` which walks the source via `Ripper.lex`, parses each comment token against a single regex, and returns `{ line: [Range, ...], branch: [...], method: [...] }`. The Directive value object itself is mostly an internal accumulator for `disabled_ranges`; users of the class don't need to reach for it.
- `LinesClassifier#classify` consults the line ranges so that `SimulateCoverage` (used for tracked-but-unloaded files) marks disabled lines as `NOT_RELEVANT`, matching the behaviour `:nocov:` already had for that path. Both this file and `SourceFile` `require_relative "directive"` directly so that requiring either one in isolation doesn't blow up.
- `SourceFile` lazily memoises per-category ranges and consumes them in the three `process_skipped_*` methods. Branches and methods both use overlap-with-range checks, so a directive that sits inside a method body or a branch body still skips the enclosing construct. `process_skipped_branches` also consults `branch.report_line` so an inline directive on the condition line of a multi-line `if` (where the arm body's source range starts on a different line) still skips the arm.
- `SourceFile#warn_no_cov_deprecation` is the deprecation hook. It dedupes per-filename via a class-level `Set` (`SimpleCov::SourceFile.nocov_warned`) so noisy projects only see one line per file rather than one per occurrence.