### PR TITLE
Run CI on macOS and Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalize line endings: auto-detect text vs binary, and force LF in the
+# working tree. Spec fixtures and source files compare against "...\n", so
+# Windows checkouts must not introduce CRLF.
+* text=auto eol=lf

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -4,7 +4,8 @@ on: [push, pull_request]
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
 
     env:
       BUNDLE_WITHOUT: "benchmark"
@@ -13,6 +14,7 @@ jobs:
       fail-fast: false
 
       matrix:
+        os: [ubuntu-latest]
         ruby-version:
           - '3.1'
           - '3.2'
@@ -22,11 +24,18 @@ jobs:
           - jruby-9.4
           - jruby-10.0
           - truffleruby
+        include:
+          - os: macos-latest
+            ruby-version: ruby
+          - os: windows-latest
+            ruby-version: ruby
 
     steps:
       - uses: actions/checkout@v6
 
-      - run: rm Gemfile.lock
+      - name: Remove Gemfile.lock
+        run: rm Gemfile.lock
+        shell: bash
 
       - uses: ruby/setup-ruby@v1.307.0
         with:
@@ -36,11 +45,11 @@ jobs:
 
       - name: Run tests
         run: bundle exec rake test
-        if: "!contains(matrix.ruby-version, 'jruby') && matrix.ruby-version != 'truffleruby'"
+        if: "!contains(matrix.ruby-version, 'jruby') && matrix.ruby-version != 'truffleruby' && matrix.os != 'windows-latest'"
 
-      # Run only `rake spec` on truffleruby and jruby, because `rake` runs
-      # cucumber which requires headless Chrome via cuprite/ferrum — this is
-      # unreliable on alternative Ruby implementations.
-      - name: Run specs (alternative implementations)
+      # Run only `rake spec` on truffleruby, jruby, and Windows. `rake` runs
+      # cucumber which requires headless Chrome via cuprite/ferrum, which is
+      # unreliable on alternative Ruby implementations and on Windows runners.
+      - name: Run specs only
         run: bundle exec rake spec
-        if: "contains(matrix.ruby-version, 'jruby') || matrix.ruby-version == 'truffleruby'"
+        if: "contains(matrix.ruby-version, 'jruby') || matrix.ruby-version == 'truffleruby' || matrix.os == 'windows-latest'"

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     env:
       BUNDLE_WITHOUT: "benchmark"
       JRUBY_OPTS: "--debug"
@@ -14,10 +15,16 @@ jobs:
       fail-fast: false
 
       matrix:
+        os: [ubuntu-latest]
         ruby-version:
           - ruby-head
           - jruby-head
           - truffleruby-head
+        include:
+          - os: macos-latest
+            ruby-version: ruby-head
+          - os: windows-latest
+            ruby-version: ruby-head
 
     steps:
       - uses: actions/checkout@v6
@@ -29,11 +36,11 @@ jobs:
 
       - name: Run tests
         run: bundle exec rake test
-        if: "!contains(matrix.ruby-version, 'jruby') && matrix.ruby-version != 'truffleruby-head'"
+        if: "!contains(matrix.ruby-version, 'jruby') && matrix.ruby-version != 'truffleruby-head' && matrix.os != 'windows-latest'"
 
-      # Run only `rake spec` on truffleruby and jruby, because `rake` runs
-      # cucumber which requires headless Chrome via cuprite/ferrum — this is
-      # unreliable on alternative Ruby implementations.
-      - name: Run specs (alternative implementations)
+      # Run only `rake spec` on truffleruby, jruby, and Windows. `rake` runs
+      # cucumber which requires headless Chrome via cuprite/ferrum, which is
+      # unreliable on alternative Ruby implementations and on Windows runners.
+      - name: Run specs only
         run: bundle exec rake spec
-        if: "contains(matrix.ruby-version, 'jruby') || matrix.ruby-version == 'truffleruby-head'"
+        if: "contains(matrix.ruby-version, 'jruby') || matrix.ruby-version == 'truffleruby-head' || matrix.os == 'windows-latest'"

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -223,7 +223,10 @@ RSpec.describe SimpleCov::Filter do
     skip "requires the default configuration" if ENV["SIMPLECOV_NO_DEFAULTS"]
 
     def a_file(path)
-      path = File.join(SimpleCov.root, path) unless path.start_with?("/")
+      # Treat both Unix-style `/foo` and Windows-style `C:/foo` as absolute.
+      # `File.absolute_path?` alone doesn't recognize `/foo` on Windows;
+      # `start_with?("/")` alone doesn't recognize drive-letter paths.
+      path = File.join(SimpleCov.root, path) unless path.start_with?("/") || File.absolute_path?(path)
       SimpleCov::SourceFile.new(path, [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil])
     end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -3,8 +3,13 @@
 # Dogfood: start Ruby's Coverage module *before* requiring simplecov so
 # simplecov's own lib/ files get tracked. Set SIMPLECOV_NO_DOGFOOD=1 to
 # skip — useful when running individual specs interactively or when a
-# dependency's behaviour around Coverage is being investigated.
-unless ENV["SIMPLECOV_NO_DOGFOOD"]
+# dependency's behaviour around Coverage is being investigated. Skipped
+# on Windows because the Unix-only specs we exclude there (cross-process
+# flock, `SimpleCov.root("/")`) uniquely cover a handful of lib/ lines,
+# so the 100% threshold can't be met from a Windows run alone.
+DOGFOOD_DISABLED = ENV["SIMPLECOV_NO_DOGFOOD"] || Gem.win_platform?
+
+unless DOGFOOD_DISABLED
   require "coverage"
   # Build the criteria hash by what the runtime actually supports — JRuby
   # silently ignores `branches:`/`methods:` (with warnings); some engines
@@ -39,7 +44,7 @@ SimpleCov.remove_filter %r{\A(test|features|spec|autotest)/}
 
 SimpleCov.coverage_dir("tmp/coverage")
 
-unless ENV["SIMPLECOV_NO_DOGFOOD"]
+unless DOGFOOD_DISABLED
   # `start_tracking` (not `start`) handles bookkeeping (pid,
   # process_start_time, fork hook) without auto-installing the at_exit
   # formatter — the after(:suite) hook below drives the report

--- a/spec/result_merger_spec.rb
+++ b/spec/result_merger_spec.rb
@@ -301,7 +301,9 @@ RSpec.describe SimpleCov::ResultMerger do
       end.not_to raise_error
     end
 
-    it "blocks other processes" do
+    it "blocks other processes" do # rubocop:disable RSpec/ExampleLength
+      skip "POSIX shell redirection and cross-process flock semantics are Unix-only" if Gem.win_platform?
+
       file = Tempfile.new("foo")
 
       test_script = <<-CODE

--- a/spec/return_codes_spec.rb
+++ b/spec/return_codes_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe "return codes" do # rubocop:disable RSpec/DescribeClass
       end
     end
 
-    let(:capture)         { Open3.capture3(command) }
+    let(:capture)         { Open3.capture3(env, command) }
+    let(:env)             { {} }
     let(:captured_stderr) { capture[1] }
     let(:status)          { capture[2] }
 
@@ -56,7 +57,7 @@ RSpec.describe "return codes" do # rubocop:disable RSpec/DescribeClass
       end
 
       context "when print_error_status is disabled" do
-        let(:command) { "PRINT_ERROR_STATUS=false #{super()}" }
+        let(:env) { super().merge("PRINT_ERROR_STATUS" => "false") }
 
         it "has a non-zero exit status" do
           expect(status.exitstatus).not_to be_zero

--- a/spec/useless_results_remover_spec.rb
+++ b/spec/useless_results_remover_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe SimpleCov::UselessResultsRemover do
 
   context "when SimpleCov.root is the filesystem root" do
     around do |example|
+      skip "filesystem root semantics are Unix-only" if Gem.win_platform?
+
       previous_root = SimpleCov.root
       described_class.instance_variable_set(:@root_regx, nil)
       SimpleCov.root("/")


### PR DESCRIPTION
Our CI matrix only exercised Ubuntu, so platform-specific bugs (Windows lacking `fork`, path-separator assumptions, macOS-specific filesystem behavior) only ever surfaced once they hit a user. This adds macOS and Windows jobs to both `stable.yml` and `unstable.yml`.

To keep the job count modest, each new OS gets a single MRI entry via `matrix.include` rather than fanning out across every Ruby version:

- **stable.yml**: 8 Ubuntu jobs (unchanged) + 1 macOS on Ruby 3.4 + 1 Windows on Ruby 3.4
- **unstable.yml**: 3 Ubuntu jobs (unchanged) + 1 macOS on `ruby-head` + 1 Windows on `ruby-head`

The macOS jobs run the full `rake test`. Windows runs `rake spec` only, since the cucumber suite drives headless Chrome via cuprite/ferrum and the same flakiness that already excludes JRuby and TruffleRuby applies on Windows runners. The existing skip condition is extended to cover `matrix.os == 'windows-latest'`.

`rm Gemfile.lock` is pinned to `shell: bash` so the step is unambiguous on Windows (where the default shell is PowerShell and `rm` is an alias for `Remove-Item`).

Resolves https://github.com/simplecov-ruby/simplecov/issues/940.