### PR TITLE
Create a GitHub Release when pushing a gem

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -35,3 +35,18 @@ jobs:
 
       # Release
       - uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1
+
+      # release-gem pushes the vX.Y.Z tag but does not open a GitHub Release,
+      # so create one for the tag it just pushed. Mark it as a pre-release when
+      # the gem version is a prerelease (e.g. 1.0.0.rc1) so it does not show as
+      # "Latest" or nudge `gem install` users toward it.
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="$(ruby -Ilib -rsimplecov/version -e 'print SimpleCov::VERSION')"
+          flags=(--generate-notes --verify-tag)
+          if [ "$(ruby -Ilib -rsimplecov/version -e 'print Gem::Version.new(SimpleCov::VERSION).prerelease?')" = "true" ]; then
+            flags+=(--prerelease)
+          fi
+          gh release create "v${version}" --title "v${version}" "${flags[@]}"


### PR DESCRIPTION
The Push Gem workflow publishes the gem and pushes the version tag through `rubygems/release-gem`, but it never opened a GitHub Release, so the Releases page had to be updated by hand after each release.

This adds a step that runs after `release-gem` and creates a Release for the tag it just pushed. It uses `--generate-notes` for the body and `--verify-tag` so it only ever targets a tag that already exists on the remote. When `SimpleCov::VERSION` is a prerelease (`Gem::Version#prerelease?` is true, as for `1.0.0.rc1`) the Release is marked `--prerelease`, so release candidates do not appear as Latest or nudge `gem install` users toward them. Final versions get a normal Release.