### PR TITLE
Stop matching the :nocov: regex twice on every classified line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
 
 ## Performance
 * Simulating a tracked-but-unloaded file no longer parses it to synthesize branch and method tuples when neither branch nor method coverage is enabled. Nothing reads those tuples in that case, and the Prism parse that produces them is over half the cost of simulating a file, paid once per tracked file in every process. On a 400 file synthetic project the injection pass drops from 0.526 to 0.222 ms per file for the default line-coverage-only configuration. Suites with branch or method coverage on are unaffected, and the line classification is identical either way. Reported with measurements by @andriytyurnikov. See #1250.
+* Classifying the lines of a tracked-but-unloaded file is roughly 10% cheaper, which is what remains of that per-file cost once the synthesis above is skipped — and unlike the synthesis, it is paid under every configuration. `LinesClassifier#classify` ran the `:nocov:` regex twice for every line — once to toggle skipping and once inside `not_relevant_line?`. A marker is always a comment, so the cheaper whitespace-or-comment test now gates the token match, and a line of real code (most of a source file) no longer pays for it at all. Over SimpleCov's own `lib/` (104 files, 8,845 lines) the whole simulation pass drops 11% on a line-coverage-only run and 7% with synthesis on. `benchmarks/simulate_coverage.rb` covers this path, which had no benchmark before — only `collate` and `Result` did, so nothing measured the per-process work at exit.
 
 1.0.3 (2026-07-26)
 ==================

--- a/benchmarks/simulate_coverage.rb
+++ b/benchmarks/simulate_coverage.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# What it costs to simulate coverage for tracked-but-unloaded files — the
+# work `SimpleCov.result` does at exit for every file a `track_files` /
+# `cover` glob matched that the process never loaded.
+#
+# This is per process, so a parallel run pays it once per worker, and each
+# worker loads only a fraction of the code: nearly every worker simulates
+# nearly the whole project.
+#
+# The two reports are the two configurations that matter. Branch and method
+# coverage are opt-in, and when neither is on, the statically derived
+# branch/method tuples are never read — so that run skips the Prism parse
+# and only classifies lines.
+#
+# The corpus is SimpleCov's own lib/, so there is no fixture to build.
+#
+# Usage:
+#
+#   ruby benchmarks/simulate_coverage.rb
+
+require "benchmark/ips"
+require "coverage"
+require_relative "../lib/simplecov"
+
+FILES = Dir[File.expand_path("../lib/**/*.rb", __dir__)]
+LINES = FILES.sum { |file| File.foreach(file).count }
+
+puts "#{FILES.size} files, #{LINES} lines"
+
+Benchmark.ips do |bm|
+  bm.report "line coverage only (default)" do
+    FILES.each { |file| SimpleCov::SimulateCoverage.call(file, synthesize: false) }
+  end
+
+  bm.report "branch / method coverage enabled" do
+    FILES.each { |file| SimpleCov::SimulateCoverage.call(file, synthesize: true) }
+  end
+
+  bm.compare!
+end

--- a/lib/simplecov/lines_classifier.rb
+++ b/lib/simplecov/lines_classifier.rb
@@ -34,21 +34,29 @@ module SimpleCov
     def classify(lines)
       lines = lines.to_a
       directive_disabled = directive_disabled_line_set(lines)
-      skipping = false
+      @skipping = false
 
       lines.map.with_index(1) do |line, line_number|
-        skipping = !skipping if self.class.no_cov_line?(line)
-        not_relevant_line?(line, line_number, skipping, directive_disabled) ? NOT_RELEVANT : RELEVANT
+        classify_line(line, line_number, directive_disabled)
       end
     end
 
   private
 
-    def not_relevant_line?(line, line_number, skipping, directive_disabled)
-      skipping ||
-        self.class.no_cov_line?(line) ||
-        directive_disabled.include?(line_number) ||
-        self.class.whitespace_line?(line)
+    # A `:nocov:` marker is itself a comment, so the cheap
+    # whitespace-or-comment test can gate the token match: a line of real
+    # code cannot be a marker, and no longer pays to be checked against
+    # one. That matters because this runs per line of every
+    # tracked-but-unloaded file, once in every process of a parallel run.
+    def classify_line(line, line_number, directive_disabled)
+      if self.class.whitespace_line?(line)
+        @skipping = !@skipping if self.class.no_cov_line?(line)
+        NOT_RELEVANT
+      elsif @skipping || directive_disabled.include?(line_number)
+        NOT_RELEVANT
+      else
+        RELEVANT
+      end
     end
 
     def directive_disabled_line_set(lines)

--- a/sig/internal/simplecov/lines_classifier.rbs
+++ b/sig/internal/simplecov/lines_classifier.rbs
@@ -2,6 +2,9 @@ module SimpleCov
   # Classifies whether lines are relevant for code coverage analysis.
   # Comments & whitespace lines, and :nocov: token blocks, are considered not relevant.
   class LinesClassifier
+    # Carries the `:nocov:` toggle across one `classify` pass.
+    @skipping: bool
+
     RELEVANT: 0
 
     NOT_RELEVANT: nil
@@ -22,7 +25,7 @@ module SimpleCov
 
     private
 
-    def not_relevant_line?: (untyped line, untyped line_number, untyped skipping, untyped directive_disabled) -> untyped
+    def classify_line: (untyped line, untyped line_number, untyped directive_disabled) -> untyped
 
     def directive_disabled_line_set: (untyped lines) -> untyped
   end

--- a/spec/lines_classifier_spec.rb
+++ b/spec/lines_classifier_spec.rb
@@ -33,6 +33,20 @@ RSpec.describe SimpleCov::LinesClassifier do
       end
     end
 
+    # `classify` reaches `no_cov_line?` only for lines that already passed
+    # the whitespace-or-comment test, so an invalid byte sequence is caught
+    # there first. `SourceFile::SkipChunks` calls this directly on raw
+    # source, though, where it can still meet one.
+    describe ".no_cov_line?" do
+      it "is false for a line with an invalid UTF-8 byte sequence" do
+        expect(described_class.no_cov_line?("# :nocov: \xF1\xEB\xE2")).to be(false)
+      end
+
+      it "is true for a well-formed marker" do
+        expect(described_class.no_cov_line?("# :nocov:")).to be(true)
+      end
+    end
+
     describe "not-relevant lines" do
       it "determines whitespace is not-relevant" do
         classified_lines = classifier.classify [

--- a/spec/simulate_coverage_spec.rb
+++ b/spec/simulate_coverage_spec.rb
@@ -179,6 +179,20 @@ RSpec.describe SimpleCov::SimulateCoverage do
             .to eq(described_class.call(path)["lines"])
         end
       end
+
+      # Empty tuples alone would also be satisfied by parsing and discarding
+      # the result. The point of the flag is that the Prism parse — over half
+      # the cost of simulating a file — never happens.
+      it "does not parse the file at all",
+         if: SimpleCov::StaticCoverageExtractor.available? do
+        with_tmp_source(source) do |path|
+          allow(SimpleCov::StaticCoverageExtractor).to receive(:call).and_call_original
+
+          described_class.call(path, synthesize: false)
+
+          expect(SimpleCov::StaticCoverageExtractor).not_to have_received(:call)
+        end
+      end
     end
 
     # `Coverage.result` reports no lines for a file loaded under a branch-only


### PR DESCRIPTION
Follow-on to #1252, on the same per-process path. Skipping the branch and method synthesis took the bulk of the cost out of a line-coverage-only run; classification is what remains, and unlike the synthesis it is paid under every configuration.

`LinesClassifier#classify` matched the `:nocov:` regex twice for every line — once to toggle skipping, once inside `not_relevant_line?`:

```ruby
lines.map.with_index(1) do |line, line_number|
  skipping = !skipping if self.class.no_cov_line?(line)          # match 1
  not_relevant_line?(line, line_number, skipping, directive_disabled)  # match 2
end
```

A `:nocov:` marker is always a comment, so the cheaper whitespace-or-comment test now gates the token match, and a line of real code — most of a source file — no longer pays for it at all.

Measured over SimpleCov's own `lib/` (104 files, 8,845 lines), median of three runs:

```
classify alone                48.31 -> 43.36 ms   -10%
simulate, line coverage only  67.58 -> 60.09 ms   -11%
simulate, synthesis enabled   85.30 -> 79.41 ms    -7%
```

Classification output is unchanged; the existing specs pin it.

`benchmarks/simulate_coverage.rb` is new. Nothing measured this path before — only `collate` and `Result` had benchmarks, so the per-process work at exit was invisible.

Two smaller things in here:

The `rescue` in `LinesClassifier.no_cov_line?` is no longer reachable from `classify`, since an invalid byte sequence now fails the whitespace test first. `SourceFile::SkipChunks` still calls it directly on raw source, so it keeps its rescue and gains a direct spec.

One spec added to `simulate_coverage_spec.rb`: `synthesize: false` skips the Prism parse outright rather than parsing and discarding. The existing specs assert the tuples come back empty, which parsing-then-discarding would also satisfy — the point of the flag is that the parse never happens.

Refs #1250.
