### PR TITLE
bump powerassert to fix ci failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
     parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
-    power_assert (3.0.1)
+    power_assert (3.1.0)
     prism (1.9.0)
     racc (1.8.1)
     racc (1.8.1-java)

--- a/test_projects/faked_project/Gemfile.lock
+++ b/test_projects/faked_project/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     multi_test (1.1.0)
-    power_assert (3.0.1)
+    power_assert (3.1.0)
     prism (1.9.0)
     rake (13.4.2)
     rspec (3.13.2)
@@ -101,6 +101,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  bundler (4.0.16) sha256=d6ca5dd440c24f9abce9844cf44cc8e18c6a553de65a47efb4544137af92c47d
   cucumber (11.1.1) sha256=dedd44f4a14b50af798c13b50c3221afa41be8051f5fce666c37cd09f8564ec4
   cucumber-ci-environment (11.0.0) sha256=0df79a9e1d0b015b3d9def680f989200d96fef206f4d19ccf86a338c4f71d1e2
   cucumber-core (16.2.0) sha256=592b58a95cf42feef8e5a349f68e363784ba3b6568ffbcf6776e38e136cf970b
@@ -127,7 +128,7 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   multi_test (1.1.0) sha256=e9e550cdd863fb72becfe344aefdcd4cbd26ebf307847f4a6c039a4082324d10
-  power_assert (3.0.1) sha256=8ce9876716cc74e863fcd4cdcdc52d792bd983598d1af3447083a3a9a4d34103
+  power_assert (3.1.0) sha256=fefe98ed5d3140628138f3f9f9194d6ece01f1320e69700d3c928adca7518251
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587


### PR DESCRIPTION
Fixes https://github.com/simplecov-ruby/simplecov/actions/runs/31975092696/job/95233232381?pr=1275#step:5:42

>        -Line coverage by file (75.00%) is below the expected minimum coverage (100.00%) in lib/faked_project/framework_specific.rb.
>       +bundler: failed to load command: rake (/home/runner/work/simplecov/simplecov/vendor/bundle/ruby/4.0.0/bin/rake)
>       +/opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundler/definition.rb:718:in 'Bundler::Definition#materialize': Could not find power_assert-3.0.1 in locally installed gems (Bundler::GemNotFound)