### PR TITLE
Probe the mutation matrix in CI (not for merge)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -11,7 +11,9 @@ env:
   # seconds a subject, depending on how many examples the subject drags in, so
   # 50 is the size that keeps even a shard of the slow ones inside the timeout
   # below while leaving an ordinary pull request on a single runner.
-  SUBJECTS_PER_SHARD: 50
+  # Lowered on this probe branch only, to force a fan-out from a handful of
+  # subjects. main keeps 50.
+  SUBJECTS_PER_SHARD: 2
   # A ceiling on the fan-out, so a formatting pass over the whole tree grows
   # the shards rather than the runners. Mutant selects a subject whose line
   # range the diff touches, and a comment removed above a method moves every

--- a/lib/simplecov/coverage_statistics.rb
+++ b/lib/simplecov/coverage_statistics.rb
@@ -13,6 +13,7 @@ module SimpleCov
     # Strength is remultiplied by loc because files have different strengths and
     # line counts, giving them a different weight in the total.
     def self.from(coverage_statistics)
+      # Probe branch for the mutation matrix. Not for merge.
       sum_covered, sum_missed, sum_omitted, sum_total_strength =
         coverage_statistics.reduce(ZERO_STATS) do |(covered, missed, omitted, total_strength), stats|
           [
@@ -27,6 +28,7 @@ module SimpleCov
     end
 
     def initialize(covered:, missed:, omitted: 0, total_strength: 0, percent: nil)
+      # Probe branch for the mutation matrix. Not for merge.
       @covered  = covered
       @missed   = missed
       @omitted  = omitted
@@ -38,12 +40,14 @@ module SimpleCov
   private
 
     def compute_percent(covered, missed, total)
+      # Probe branch for the mutation matrix. Not for merge.
       return 100.0 if missed.zero?
 
       covered * 100.0 / total
     end
 
     def compute_strength(total_strength, total)
+      # Probe branch for the mutation matrix. Not for merge.
       return 0.0 if total.zero?
 
       total_strength.fdiv(total)


### PR DESCRIPTION
Validates the sharded mutation workflow added in 8479155d, whose matrix path has never executed: every push to main since has selected zero subjects and skipped it.

This branch adds a marker comment inside four methods of one small file so the workflow selects a handful of subjects, and lowers `SUBJECTS_PER_SHARD` to 2 **on this branch only** so those few fan out across more than one runner. `main` keeps 50.

What that exercises, none of which has run in CI yet:

- the `shards` output feeding `fromJSON` into `strategy.matrix`
- the pull-request base-ref branch of the plan job
- the `Make the base revision available` step
- `rake mutant:shard[...]` through the workflow's YAML and shell quoting

Locally both shards report 100%:

    Shard 0 of 2: 2 of 4 subjects  Coverage: 100.00%
    Shard 1 of 2: 2 of 4 subjects  Coverage: 100.00%

Close without merging once the run is green.